### PR TITLE
Retrait référence site web et projet hypothétique

### DIFF
--- a/yunohost_project_organization_fr.md
+++ b/yunohost_project_organization_fr.md
@@ -9,9 +9,9 @@ Un conseil oriente l’évolution du projet YunoHost, et des groupes d’intér�
 ## Définition de YunoHost
 
 ###  Objectifs
-Selon le site web : « Le but de YunoHost est de rendre accessibles au plus grand nombre l’installation et l’administration d’un serveur, sans délaisser la qualité et la fiabilité du logiciel. »
+Le but de YunoHost est de rendre accessibles au plus grand nombre l’installation et l’administration d’un serveur, sans délaisser la qualité et la fiabilité du logiciel.
 
-Nous proposons de limiter YunoHost au simple logiciel et de ne traiter aucun service auxiliaire estampillé sous le même nom (support payant, dns, hébergement). La fourniture de services devrait être laissée à d'autres structures gravitant autour du logiciel, qu'elles soient des entreprises ou des associations. Cela afin de concentrer l'activité de Yunohost sur la qualité du logiciel.
+YunoHost se limite au simple logiciel et ne traite aucun service auxiliaire (support payant, dns, hébergement). La fourniture de services est laissée à d'autres structures gravitant autour du logiciel, qu'elles soient des entreprises ou des associations. Cela afin de concentrer l'activité de Yunohost sur la qualité du logiciel.
 Ce postulat pose la question des services comme nohost.me, qui devra être débattue.
 
 ###  Valeurs


### PR DESCRIPTION
Pas besoin de citer le site web je pense, ce document faisant référence (boucle infinie :D)
Qui plus est, il me semble que la limitation au logiciel (pas de service auxiliaire) faisant consensus, et devrait donc être affirmée dans le document plutôt que proposée.
Qu'en dites-vous ?