### PR TITLE
Système de build des paquets Debian dans le giron de Infra

### DIFF
--- a/yunohost_project_organization_fr.md
+++ b/yunohost_project_organization_fr.md
@@ -54,18 +54,20 @@ La constitution de groupes part du constat que YunoHost compte beaucoup de sous-
 - Groupe Distribution
  - Création et maintenance des images d'installation sur diverses architectures
  - Distribution des images
- - Gestion de la distribution des paquets Debian.
 
 - Groupe Infra/Adminsys
- -  Infrastructure
- - Site web (wiki, forum, salon de discussion, redmine, mumble)
+ - Infrastructure (maintenance, monitoring des machines)
+ - Site web (yunohost.org, forum.yunohost.org, redmine)
+ - XMPP
  - Démo
+ - Service de build des paquets Debian
  - Services
     - ip.yunohost.org
     - yunoport
-    - nohost.me
+    - DynDNS
     - yunodash
     - yunopaste
+    - weblate
 
 - Groupe Apps
  - Apps Officielles


### PR DESCRIPTION
Historiquement, la maintenance du système de build des paquets Debian relèvent des "adminsys de YunoHost". Les sources des paquets Debian, quant à elles, relèvent des groupes Dev+Infra.

Il me semble donc plus approprié de remettre cet item dans le giron du groupe Infra, et de laisser au groupe Distrib la maintenance/creation des images Yunohost (ISO, image raspberry & co, ...). La création du groupe Distrib a été faite suite à cette demande spécifiquement.