### PR TITLE
Retrait mainteneurs communautaires du groupe Apps

### DIFF
--- a/yunohost_project_organization_fr.md
+++ b/yunohost_project_organization_fr.md
@@ -62,8 +62,7 @@ La constitution de groupes part du constat que YunoHost compte beaucoup de sous-
 
 - Groupe Apps
  - Apps Officielles
- - Apps Communautaires
- - outils de développements d'app (package_checker, package linter)
+ - Outils et processus de développements d'app (package_checker, package linter, manifeste, YEP, ...)
 
 - Groupe Communication
  - Documentation


### PR DESCRIPTION
Faisant suite à une discussion XMPP et divers tickets, je propose que le groupe Apps soit restreint à:
1) ceux intéressés par la stratégie apps (manifeste, helpers, yep, etc)
2) les mainteneurs d'apps officielles.

Les mainteneurs d'apps non-officielles ou occasionnels sont en fait des "utilisateurs" du groupe app à consulter et impliquer au même titre que les utilisateurs finaux (voir plus, mentoring etc).

Si on les intègre au groupe apps, deux problèmes se posent : beaucoup de monde à gérer, et ces personnes n'ont pas forcément envie de s'impliquer dans les apps officielles ou la stratégie. Quel serait alors leur périmètre d'implication dans le groupe Apps ? Je ne vois pas trop.

Si on ne les intègre pas, il faut par contre les impliquer. Le mentoring me semble une super idée (déjà suggérée il y a longtemps). On peut ainsi accompagner les mainteneurs intéressés, les conseiller sur leurs apps, et pourquoi pas - si ils ont envie - les intégrer ensuite dans le groupe Apps pour soit 1) s'impliquer sur les stratégies apps, ou 2) rendre leur app officielle.
Ensuite, leur implication passe aussi par le forum et le XMPP, ou tout le monde est bienvenue pour discuter et échanger. Et enfin par les décisions du groupe Apps (lecture, participation). Leur avis pouvant être pris en compte lors de décisions du groupe.

Si besoin, on peut même donner une voix de décision aux mainteneurs non-membres du groupe (une voix pour l'ensemble, pas une pour chacun sinon on retombe sur le problème initial - par exemple vote public sur le forum et le résultat compte pour une voix). Mais bon là ça devient compliqué ... Pas sur que ce soit nécessaire

Qu'en dites-vous ?