### PR TITLE
[mod] admin rights for Apps group: remove redmine access.

### DIFF
--- a/yunohost_project_organization.md
+++ b/yunohost_project_organization.md
@@ -248,7 +248,6 @@ This part list administration rights for differents groups of YunoHost project:
 
 ### Apps
 - GitHub: YunoHost-Apps [Owner](https://github.com/orgs/YunoHost-Apps/people?utf8=%E2%9C%93&query=%20role%3Aowner) (permission to push and merge on all repositories),
-- Redmine: [Apps project member](https://dev.yunohost.org/projects/apps),
 - GitHub: [Apps team member inside YunoHost's organization](https://github.com/orgs/YunoHost/teams/apps) (permission to push, merge…),
 - Continous integration: access to [CI-Apps](https://ci-apps.yunohost.org),
 - XMPP: [Apps channel moderator](https://im.yunohost.org/logs/apps),

--- a/yunohost_project_organization_fr.md
+++ b/yunohost_project_organization_fr.md
@@ -248,7 +248,6 @@ Cette partie liste les kits de droits d’administration pour les différents gr
 
 ### Apps
 - GitHub : propriétaire (Owner) [de l’organisation YunoHost-Apps](https://github.com/orgs/YunoHost-Apps/people?utf8=%E2%9C%93&query=%20role%3Aowner),
-- Redmine : membre du [projet `Apps`](https://dev.yunohost.org/projects/apps),
 - GitHub : membre de l’[équipe `Apps` de l’organisation `YunoHost`](https://github.com/orgs/YunoHost/teams/apps),
 - Intégration continue : accès à [CI-Apps](https://ci-apps.yunohost.org),
 - XMPP : modérateur sur le [salon `Apps`](xmpp:apps@conference.yunohost.org?join),


### PR DESCRIPTION
Apps issues are no more on Redmine and are now on GitHub.
This access is useless.