### PR TITLE
Update groups

### DIFF
--- a/yunohost_project_organization_fr.md
+++ b/yunohost_project_organization_fr.md
@@ -204,13 +204,13 @@ Dans ce cas, l'auteur annonce sur le fil de discussion de la PR qu'il souhaite e
 ## Composition des groupes
 
 - Conseil : Bram, ljf, Maniack, Moul, Aleks, frju365, Josue, JimboJoe
-- Core Dev : Aleks, Bram, ljf, JimboJoe, Josue
-- Apps : Maniack, frju365, JimboJoe, Josue, ljf, (cyp? Maxime? Scith? Tostaki? Jibec? tituspijean? nicofrand? amnol? Gofannon? ...?)
-- Infra : Bram, ljf, Aleks, Maniack, (pitchum? ...?)
-- Support & Doc : Aleks, ljf, frju365, (ppr? ...?)
+- Core : Aleks, Bram, ljf, JimboJoe, Josue, (...?)
+- Apps : Maniack, frju365, JimboJoe, Josue, ljf, (remove : cyp? Maxime? Scith? Tostaki?) (add : Jibec? tituspijean? nicofrand? amnol? Gofannon? ...?)
+- Infra : Bram, ljf, Aleks, Maniack, (add: pitchum? ...?)
+- Support & Doc : Aleks, ljf, frju365, (add: ppr? ...?)
 - Distribution : Aleks, (...?)
-- Communication : Aleks, frju365, (Bram?)
-- Translation : (Jibec? BoF? Quent-i? ...?)
+- Communication : Aleks, frju365, (add : Bram? ...?)
+- Translation : (add: Jibec? BoF? Quent-i? ...?)
 
 
 ## Droits d’administration afférents aux groupes

--- a/yunohost_project_organization_fr.md
+++ b/yunohost_project_organization_fr.md
@@ -207,13 +207,13 @@ Dans ce cas, l'auteur annonce sur le fil de discussion de la PR qu'il souhaite e
 
 - Conseil : Bram, ljf, Maniack, Moul, Aleks, frju365, Josue, JimboJoe
 - Core : Aleks, Bram, ljf, JimboJoe, Josue
-- Apps : Maniack, frju365, JimboJoe, Josue, ljf (add : tituspijean? amnol? Gofannon? ...?)
-    - Official apps : Maniack, frju365, JimboJoe, Josue, (add : anmol)
+- Apps : Maniack, frju365, JimboJoe, Josue, ljf, anmol
+    - Official apps : Maniack, frju365, JimboJoe, Josue, anmol
 - Infra : Bram, ljf, Aleks, Maniack
 - Support & Doc : Aleks, ljf, frju365, ppr
 - Distribution : Aleks
 - Communication : Aleks, frju365, Bram
-- Translation : (add: BoF? Quent-i? Xaloc? ...?)
+- Translation : Quent-i
 
 
 ## Droits d’administration afférents aux groupes

--- a/yunohost_project_organization_fr.md
+++ b/yunohost_project_organization_fr.md
@@ -53,6 +53,8 @@ La constitution de groupes part du constat que YunoHost compte beaucoup de sous-
 - Maintien du repo YunoHost/Apps (et notamment de les listes official.json et community.json)
 - Outils de développements et tests d'application (package check, package linter, continous integration)
 
+Un sous-groupe du groupe Apps est dédié à la maintenance des apps officielles
+
 ##### Groupe Infra/Adminsys
 
 Deploie, administre, maintien et sauvegarde les différents éléments d'infrastructure et services associés
@@ -204,13 +206,14 @@ Dans ce cas, l'auteur annonce sur le fil de discussion de la PR qu'il souhaite e
 ## Composition des groupes
 
 - Conseil : Bram, ljf, Maniack, Moul, Aleks, frju365, Josue, JimboJoe
-- Core : Aleks, Bram, ljf, JimboJoe, Josue, (...?)
-- Apps : Maniack, frju365, JimboJoe, Josue, ljf, (remove : cyp? Maxime? Scith? Tostaki?) (add : Jibec? tituspijean? nicofrand? amnol? Gofannon? ...?)
-- Infra : Bram, ljf, Aleks, Maniack, (add: pitchum? ...?)
-- Support & Doc : Aleks, ljf, frju365, (add: ppr? ...?)
-- Distribution : Aleks, (...?)
-- Communication : Aleks, frju365, (add : Bram? ...?)
-- Translation : (add: Jibec? BoF? Quent-i? ...?)
+- Core : Aleks, Bram, ljf, JimboJoe, Josue
+- Apps : Maniack, frju365, JimboJoe, Josue, ljf (add : tituspijean? amnol? Gofannon? ...?)
+    - Official apps : Maniack, frju365, JimboJoe, Josue, (add : anmol)
+- Infra : Bram, ljf, Aleks, Maniackf
+- Support & Doc : Aleks, ljf, frju365, ppr
+- Distribution : Aleks
+- Communication : Aleks, frju365, Bram
+- Translation : (add: BoF? Quent-i? Xaloc? ...?)
 
 
 ## Droits d’administration afférents aux groupes

--- a/yunohost_project_organization_fr.md
+++ b/yunohost_project_organization_fr.md
@@ -34,42 +34,57 @@ Schéma d’organisation du projet YunoHost :
 
 
 #### Définition et constitution des groupes
+
 La constitution de groupes part du constat que YunoHost compte beaucoup de sous-projets (treize au total), mais que l'on ne sait pas toujours qui en est en charge ou qui y est compétent. Il est donc proposé une simplification de l'organisation des sous-projets en groupes thématiques :
 
-##### Groupe Core Dev
- - Core YunoHost
- - Moulinette
- - Admin web
- - SSOwat
- - Dynette
- - YNH-Dev
+##### Groupe Core
 
-##### Groupe Distribution
- - Création et maintenance des images d'installation sur diverses architectures
- - Distribution des images
- - Gestion de la distribution des paquets Debian.
-
-##### Groupe Infra/Adminsys
- - Infrastructure
- - Site web (wiki, forum, salon de discussion, redmine, mumble)
- - Démo
- - Services
-    - [ip.yunohost.org](https://ip.yunohost.org/) et ip6.yunohost.org
-    - [yunoports](http://ports.yunohost.org/)
-    - nohost.me et noho.st
-    - [yunodash](https://dash.yunohost.org/)
-    - [yunopaste](http://paste.yunohost.org/)
+- Core YunoHost
+- Moulinette
+- Webadmin
+- SSOwat
+- Dynette
+- YNH-Dev
 
 ##### Groupe Apps
- - Apps Officielles
- - Apps Communautaires
- - outils de développements d'app (package_checker, package linter)
+
+- Apps Officielles
+- Apps Communautaires
+- Maintien du repo YunoHost/Apps (et notamment de les listes official.json et community.json)
+- Outils de développements et tests d'application (package check, package linter, continous integration)
+
+##### Groupe Infra/Adminsys
+
+Deploie, administre, maintien et sauvegarde les différents éléments d'infrastructure et services associés
+
+- Administration "bas-niveau" (serveurs, conteneurs, configuration réseau, stack mail, stack xmpp, ...)
+- Services "techniques" (ip, ports, dynette, paste, dash, ...)
+- Services pour les utilisateurs et la communication (simone, forum, chatrooms, mumble, demo, ...)
+- ...
+
+##### Groupe Distribution
+
+- Création et maintenance des images d'installation sur diverses architectures
+- Distribution des images
+- Gestion de la distribution des paquets Debian.
+
+##### Groupe Support et documentation
+
+- Entraide et support sur le forum et le salon
+- Maintenance et mise à jour de la documentation
+- Organisation du forum et du salon de support
 
 ##### Groupe Communication
- - Documentation
- - Communication (annonce évolutions du projet sur le forum, réseaux sociaux)
- - Traduction
- - Entraide (support)
+
+- Annonce d'évolutions du projet sur le forum
+- Interaction avec la communauté sur les réseaux sociaux
+- Communication sur le projet sur d'autres sites externes au projet, ou en conférence
+
+##### Groupe Traduction
+
+- Maintenance des traductions en différentes langues
+- Interaction avec les autres groupes pour l'intégration des traductions et la maintenance des outils associé
+
 
 Les groupes sont ouverts à tous les contributeurs souhaitant participer au développement de YunoHost. Chacun peut s'inscrire aux canaux de communication associés aux groupes auxquels il souhaite prendre part. Chaque inscrit est libre d'échanger avec le reste du groupe et de proposer une prise de décision à la suite d'une étape d'échange et d'amélioration de la proposition. Il est recommandé aux contributeurs de documenter au maximum leurs décisions et leurs contributions. Ceci permet de renforcer l'autonomie des groupes en cas de départs ou d'absences de certains de leurs membres.
 Afin de faciliter sa gestion, chaque groupe nomme donc un coordinateur (et un remplaçant) dont le rôle est :  

--- a/yunohost_project_organization_fr.md
+++ b/yunohost_project_organization_fr.md
@@ -204,14 +204,13 @@ Dans ce cas, l'auteur annonce sur le fil de discussion de la PR qu'il souhaite e
 ## Composition des groupes
 
 - Conseil : Bram, ljf, Maniack, Moul, Aleks, frju365, Josue, JimboJoe
-- Core Dev : Aleks, Bram, JimboJoe, Ju, ljf, Moul, opi
-- Apps : Bram, cyp, frju365, JimboJoe, Josue-T, Ju, ljf, Maniack C, Maxime, Moul, Scith, Tostaki
-- Infra : Bram, Ju, Maniack C, Moul, opi
-- Communication
-  - Com : Bram, Moul, korbak, ljf, opi, frju365
-  - Doc : Moul, Theodore
-  - Trad : Jean-Baptiste
-- Distribution : Heyyounow
+- Core Dev : Aleks, Bram, ljf, JimboJoe, Josue
+- Apps : Maniack, frju365, JimboJoe, Josue, ljf, (cyp? Maxime? Scith? Tostaki? Jibec? tituspijean? nicofrand? amnol? Gofannon? ...?)
+- Infra : Bram, ljf, Aleks, Maniack, (pitchum? ...?)
+- Support & Doc : Aleks, ljf, frju365, (ppr? ...?)
+- Distribution : Aleks, (...?)
+- Communication : Aleks, frju365, (Bram?)
+- Translation : (Jibec? BoF? Quent-i? ...?)
 
 
 ## Droits d’administration afférents aux groupes

--- a/yunohost_project_organization_fr.md
+++ b/yunohost_project_organization_fr.md
@@ -209,7 +209,7 @@ Dans ce cas, l'auteur annonce sur le fil de discussion de la PR qu'il souhaite e
 - Core : Aleks, Bram, ljf, JimboJoe, Josue
 - Apps : Maniack, frju365, JimboJoe, Josue, ljf (add : tituspijean? amnol? Gofannon? ...?)
     - Official apps : Maniack, frju365, JimboJoe, Josue, (add : anmol)
-- Infra : Bram, ljf, Aleks, Maniackf
+- Infra : Bram, ljf, Aleks, Maniack
 - Support & Doc : Aleks, ljf, frju365, ppr
 - Distribution : Aleks
 - Communication : Aleks, frju365, Bram


### PR DESCRIPTION
This is an attempt to update the composition of the various group as the list is quite outdated in my opinion. So we should either update the lists or get rid of it in the document ...

Anyway, I propose this update, both on what the mission of the various groups, and the composition of the groups itself - in a totally yolocratic and arbitrary manner.

I probably have forgotten people (sorry) but this PR is mainly meant to bring the discussion on the table and discuss collectively what to do.

In particular, I would naively propose to : 
- Integrate / propose Jibec, tituspijean, nicofrand, amnol and Gofannon in the apps group - though I have no idea of their real implication level and I am not even in the apps group myself - and I might forgot / not be aware of other people with a good implication level recently ;
- I propose to remove cyp, Maxime, Scith, and Tostaki as they seem less active - (again, sorry if I'm doing a mistake here - no offense intended and I havent really digged the question)
- Integrate / propose ppr to join the support&doc group ;
- Integrate / propose BoF and Quenti (and others?) in the translation group ;
- I don't know exactly who is in the core group or not (or the infra group) ;
- Also feel free to comment that you wish to join a group ...

Also feel free to comment if you think it is relevant to maintain such lists or not. (IMHO : it is, both to be able to have a ~relatively clear idea of who is active where, to provide acknowledgment and gratefulness to people doing things, and provide the corresponding access rights (and responsibilities))

(Ping @Psycojoker , @zamentur , @maniackcrudelis , @frju365 , @Josue-T , @JimboJoe - dunno why but I can't request a review from everybody o.O)