### PR TITLE
markdown linting

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,63 @@
+{
+    "default": true,
+    "code-block-style": {
+        "style": "fenced"
+    },
+    "code-fence-style": {
+        "style": "backtick"
+    },
+    "emphasis-style": {
+        "style": "asterisk"
+    },
+    "strong-style": {
+        "style": "asterisk"
+    },
+    "ul-style": {
+        "style": "dash"
+    },
+    "ul-indent": {
+        "indent": 2
+    },
+    "heading-style": {
+        "style": "atx"
+    },
+    "no-duplicate-heading": {
+        "siblings_only": true
+    },
+    "hr-style": {
+        "style": "---"
+    },
+    "ol-prefix": {
+        "style": "ordered"
+    },
+    "no-trailing-punctuation": {
+        "punctuation": ".,;:"
+    },
+    "no-inline-html": false,
+    "fenced-code-language": {
+        "allowed_languages": [
+            "bash",
+            "html",
+            "css",
+            "javascript",
+            "php",
+            "json",
+            "yaml",
+            "toml",
+            "markdown",
+            "text"
+        ],
+        "language_only": true
+    },
+    "proper-names": {
+        "code_blocks": false,
+        "html_elements": false,
+        "names": [
+            "YunoHost",
+            "GitHub"
+        ]
+    },
+    "line-length": false,
+    "no-reversed-links": false,
+    "no-missing-space-atx": false
+}

--- a/adminsys_charter.md
+++ b/adminsys_charter.md
@@ -3,27 +3,26 @@
 Because great powers imply great responsibilities, I commit myself as YunoHost adminsys to respect these points:
 
 ## Security
+
 The reliability and security of the project's services is the responsibility of everybody. Below are some rules meant to prevent security breaches / leaks on the infrastructure:
 
- * never save project passwords in a non-free browser or without a master password;
- * always protect personal private SSH keys with strong passwords;
- * always lock machines where keys are located before leaving them unattended;
- * always encrypt personal machines where personal SSH keys are stored;
- * never let any random people plant third party devices in your machine(s);
-
+- never save project passwords in a non-free browser or without a master password;
+- always protect personal private SSH keys with strong passwords;
+- always lock machines where keys are located before leaving them unattended;
+- always encrypt personal machines where personal SSH keys are stored;
+- never let any random people plant third party devices in your machine(s);
 
 ## Ethics / practice
 
- * do not give yourself access by escalation of privileges and ensure that the YunoHost infrastructure administration team remains in possession of its accesses;
- * verify the effectiveness of backups and rescue means before performing risky maintenance;
- * respects project users' privacy and limit to the maximum the display of private information during debugging ;
- * in case of legal requests, do not act without consulting other contributors ;
-
-
+- do not give yourself access by escalation of privileges and ensure that the YunoHost infrastructure administration team remains in possession of its accesses;
+- verify the effectiveness of backups and rescue means before performing risky maintenance;
+- respects project users' privacy and limit to the maximum the display of private information during debugging ;
+- in case of legal requests, do not act without consulting other contributors ;
 
 ## Resilience, sharing and transparency
+
 In order to ensure the resilience of the deployed infrastructure, everyone agrees to do their best to:
 
- * report to other adminsys the operations performed on the infrastructure
- * produce documentation on their infrastructure and services;
- * create an announcement on the forum to announce any important maintenance or outage.
+- report to other adminsys the operations performed on the infrastructure
+- produce documentation on their infrastructure and services;
+- create an announcement on the forum to announce any important maintenance or outage.

--- a/app_group_welcome_kit.md
+++ b/app_group_welcome_kit.md
@@ -1,19 +1,19 @@
-# Welcome kit for Apps group usage.
+# Welcome kit for Apps group usage
 
 The purpose of this document is to list all is needed when you're about to welcome a new member into the App group.
 
-### Step to perform
+## Step to perform
 
-- Add to Apps group in github. [->](https://github.com/orgs/YunoHost/teams/apps/members)
+- Add to Apps group in GitHub. [->](https://github.com/orgs/YunoHost/teams/apps/members)
 - As well for YunoHost-Apps (Must be owner of the [organization](https://github.com/orgs/YunoHost-Apps/people)). [->](https://github.com/orgs/YunoHost-Apps/teams/apps-group/members)
 - Add to Apps group on the forum [->](https://forum.yunohost.org/groups/Apps)
 - Update group members into project organization documents [->](https://github.com/YunoHost/project-organization/blob/master/yunohost_project_organization.md#composition-of-groups) and [->](https://github.com/YunoHost/project-organization/blob/master/yunohost_project_organization_fr.md#composition-des-groupes)
 - Add a public ssh key. [->](https://github.com/YunoHost/project-organization/blob/master/ynh-ssh-keys.md)
 - Add ssh key to all CI servers.
-- Create an account on ci-apps with a ramdom password (to be modified) for https://ci-apps.yunohost.org/kanboard. [->](https://ci-apps.yunohost.org/yunohost/admin/)
+- Create an account on ci-apps with a ramdom password (to be modified) for <https://ci-apps.yunohost.org/kanboard>. [->](https://ci-apps.yunohost.org/yunohost/admin/)
 - Create an account on ci-apps-dev for jenkins. [->](https://ci-apps-dev.yunohost.org/yunohost/admin)
 
-### Tools for Apps group
+## Tools for Apps group
 
 - [Official CI](https://ci-apps.yunohost.org) `ssh admin@ci-apps.yunohost.org -p 2211`
 - [CI ARM](https://ci-apps-arm.yunohost.org) `ssh admin@ci-apps-arm.yunohost.org -p 2211`
@@ -28,15 +28,15 @@ The purpose of this document is to list all is needed when you're about to welco
 - [Apps list](https://yunohost.org/#/apps)
 - [Example app](https://github.com/YunoHost/example_ynh)
 
-### Topics and repositories to follow
+## Topics and repositories to follow
 
-- https://github.com/YunoHost/example_ynh
-- All Official apps https://github.com/YunoHost-apps
-- https://github.com/YunoHost/apps
-- https://github.com/YunoHost/package_check
-- https://github.com/YunoHost/CI_package_check
-- https://github.com/YunoHost/package_linter
-- https://forum.yunohost.org/t/official-topic-for-apps-group-news/5807
-- https://forum.yunohost.org/c/announcement/official-apps
-- https://forum.yunohost.org/c/support/apps
-- https://forum.yunohost.org/c/contribute-room/apps-packaging
+- <https://github.com/YunoHost/example_ynh>
+- All Official apps <https://github.com/YunoHost-apps>
+- <https://github.com/YunoHost/apps>
+- <https://github.com/YunoHost/package_check>
+- <https://github.com/YunoHost/CI_package_check>
+- <https://github.com/YunoHost/package_linter>
+- <https://forum.yunohost.org/t/official-topic-for-apps-group-news/5807>
+- <https://forum.yunohost.org/c/announcement/official-apps>
+- <https://forum.yunohost.org/c/support/apps>
+- <https://forum.yunohost.org/c/contribute-room/apps-packaging>

--- a/apps_group_PR_model.md
+++ b/apps_group_PR_model.md
@@ -1,46 +1,54 @@
 ## Problem
+
 - *Description of why you made this PR*
 
 ## Solution
+
 - *And how you fix that*
 
 ## PR Status
+
 *Obviously, you should really check these affirmations*  
 Work finished. Package_check, basic tests and upgrade from last version OK.  
 Could be reviewed and tested.
 
 ## Validation
+
 ---
+
 *Minor decision*
-- [ ] **Upgrade previous version** : 
-- [ ] **Code review** : 
-- [ ] **Approval (LGTM)** : 
-- [ ] **Approval (LGTM)** : 
+
+- [ ] **Upgrade previous version** :
+- [ ] **Code review** :
+- [ ] **Approval (LGTM)** :
+- [ ] **Approval (LGTM)** :
 - [ ] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/APP_ynh%20BRANCH%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/APP_ynh%20BRANCH%20(Official)/) *Please replace APP and BRANCH in this link*  
 When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.
 
 *Medium decision*
-- [ ] **Complete test** : 
-- [ ] **Upgrade previous version** : 
-- [ ] **Code review** : 
-- [ ] **Code review** : 
-- [ ] **Approval (LGTM)** : 
-- [ ] **Approval (LGTM)** : 
-- [ ] **Approval (LGTM)** : 
+
+- [ ] **Complete test** :
+- [ ] **Upgrade previous version** :
+- [ ] **Code review** :
+- [ ] **Code review** :
+- [ ] **Approval (LGTM)** :
+- [ ] **Approval (LGTM)** :
+- [ ] **Approval (LGTM)** :
 - [ ] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/APP_ynh%20BRANCH%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/APP_ynh%20BRANCH%20(Official)/) *Please replace APP and BRANCH in this link*  
 When the PR is mark as ready to merge, you have to wait for 7 days before really merge it.
 
 *Major decision*
-- [ ] **Complete test** : 
-- [ ] **Complete test** : 
-- [ ] **Upgrade previous version** : 
-- [ ] **Upgrade previous version** : 
-- [ ] **Code review** : 
-- [ ] **Code review** : 
-- [ ] **Code review** : 
-- [ ] **Approval (LGTM)** : 
-- [ ] **Approval (LGTM)** : 
-- [ ] **Approval (LGTM)** : 
-- [ ] **Approval (LGTM)** : 
+
+- [ ] **Complete test** :
+- [ ] **Complete test** :
+- [ ] **Upgrade previous version** :
+- [ ] **Upgrade previous version** :
+- [ ] **Code review** :
+- [ ] **Code review** :
+- [ ] **Code review** :
+- [ ] **Approval (LGTM)** :
+- [ ] **Approval (LGTM)** :
+- [ ] **Approval (LGTM)** :
+- [ ] **Approval (LGTM)** :
 - [ ] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/APP_ynh%20BRANCH%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/APP_ynh%20BRANCH%20(Official)/) *Please replace APP and BRANCH in this link*  
 When the PR is mark as ready to merge, you have to wait for 7 days before really merge it.

--- a/ynh-keys.md
+++ b/ynh-keys.md
@@ -1,13 +1,16 @@
 # YNH SSH / GPG keys
 
 ## Security Team
-GPG Fingerprint
-```
+
+### GPG Fingerprint
+
+```text
 6CBC 45EB A625 FBF3 513D 1227 749D 8972 1735 1899
 ```
 
-GPG Public key
-```
+### GPG Public key
+
+```text
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQINBFd2yh8BEACv9FygdPXbmqdWlPJl8w9Vi3SEb+sd2+qjhAXTHzMx2WGUN/Ao
@@ -61,20 +64,23 @@ duwVhcozAw==
 -----END PGP PUBLIC KEY BLOCK-----
 ```
 
-
 ## Aleks
-SSH
-```
+
+### SSH key
+
+```text
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC2AlKi1Hz8n1VdiQcRmV5cVyWKzoiORjxezV8LX67/rJC9t5zW71vl18LWh/jZx09RPsitxXSUQfEUCbWkKk/Mrn6y5f1JBmltB7uCHdtdAXrtv+J98WS6N977yhAyTpU8yJplgu0JJxNnnGeCwmRXATj9O282lgwT1eT2/OF3MEpWucnz3Angwurzx4s9UMDwLcK5YdDfQPFdL/7XUyTs8uy8xGvJ/6v78EPOPSrf4R1Yqrl21zdt1ErDjkO47o/mMsT3sYfrOlNvmMslSBmG3PZ1dtYo7HJy6POAsWVGbnpNNMwCD9Kp53hc435TbZl66kWAh6VA7QIkiAyxLWYZr+T3Xy+MIKYlrOt2vnJoNMTV6rbE0OCi7oeQ6U2jTcfgEVanAoWXbZTdL7V8fCI8U+Vcp+hkgyiK5FTLOypvbkvcMuk7SRqbkjiNXbNKeOwOFN6g5EsoXggNFfgVj6kWXMrUB98+O/bsQ7eu/Vq3o1zVy1bsU4geZNIgEqgwot47TggEI05Wi1x2ee/3Gs2N5NM4ARzVa4vnR4CVjzfEbHuHnbyr5/0vyBUs7sNJjGl3H0+VC8HXT4F3TH/tLHXfK/bQz4flwIScBXljY7NSX4kzJpRE8CIxUIZabBCqxJoD35m+LmEdn7HdQsWh1qPBekwYW6CVuE3qCWj673+CQw== alex.aubin@mailoo.org
 ```
 
-GPG Fingerprint
-```
+### GPG Fingerprint
+
+```text
 8243 E157 D708 788E 9A7A C4E9 4606 155D 10E6 5DDD
 ```
 
-GPG Public key
-```
+### GPG Public key
+
+```text
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQGNBGEWig4BDADBNNQeUVxB74paO+0oXdJoLo8c4Piu0uKtxVYWe2wInWv3Oykd
@@ -119,35 +125,40 @@ Cb40iY1g2yw+zKCu5YEx5fO0l7QWlj6EpR9dSoMNu/HYhp7Py6JOb1ndKYfABu2a
 ```
 
 ## Bram
-SSH
-```
+
+### SSH key
+
+```text
 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAgEA3ddF0hiVizCoN60RBbegWzb7XYmvD+3vGp/tg8qQJk5BWbtAaAB4U8PlllzmxKOvCUy++dCVz8Wj3k4oe3Eo2utMZQFULNIkbvwHFQN362v4LQuAg+P2sOHz04zlIcAcD/GCiiWRI8bvfx0BhKoA+Eo6ocIicQUqCN8TPsvOkO0U8LQcwc7rXLEISakNO7zxu7OTpASXTNwGOuxI+j7OgCpTwFGpzn7RqDpDh4ZEidPuRnzsHddPtJpUj5GzZd6h2tS5lOjK2L2AIFXVvXsZ2OdmJGT/bCRrwqvDWGrJyX6fOV2SDo9hKQTUv6iDYAeDWei19elxJYYOIRvZrYbhFqo4LaoXfdQOg6RgwuLjZDiMK4NZlAP4ToDsgsz3uE/uLtuffff6r2jHwONAIpBuNPWGWo4pOV7cnJ0D2FxldiDcZwKSvGKaSEvhWQ5PU/Ux2VErXgxnGQTPsqtK1mOgNKnsaMhGNx62KhfQUc++VLQJS6GoB8CO38Cybjd8RQABAjSln1zjlQIFgDn5FiTVyehngm1YOkko+2npZvVBM0fMGJp+MgRp0vp2zYe9jKR0CJ+2p32elwYiKOfG315gDqKjLrUY+XK03eH50NnhoZW5SjaZtCzjpm6FaLgKBH4UVICq/qLAzXx7KryHC1qA0D6R572wETSiKIQS7Wdu/PM= psycojoker@Raspoutine
 ```
 
-GPG Fingerprint
-```
+### GPG Fingerprint
+
+```text
 ```
 
-GPG Public key
+### GPG Public key
 
+```text
 ```
-```
-
 
 ## Ericg
-SSH
-```
+
+### SSH key
+
+```text
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpcN7Mced/oeb2H/oY2FpsYMU2TDjgF1haVpSA6q9w5ocdsX5vEyTJKE4j1qLHqdq1d6je8Oj4XorbEGgFv4YxPLVZnzTHQfaMfrSPIGPP5Jnuq1PZ70QTkhbeMovGN2VDy9561ndSfRwfg7iC5wmwk/XmzRM4gqWsJlXUecYsuF5iML20pW1+q8693BNiqEfH1OjzYG8Z9bgeIdG5DBIfxhwXfj5syfoWwP+VbYORKu19U9VWXEACoKoIM4TQciooLeI/mHvqgVl6KX6m03EXZ7J+99tGGuIhKw5rtMP0vgNoYki20KRhRBT4molGtUOAhMu5nFg1k7yWhmfGx1kAmGz1jqVEe8195/qGPsl8jWKD0g/vtYoBhef3aIT/LbCWSXtJo3bqQ1kdBFhiydNBHs+UPhzlAKIUK0+s3Q3KBVppKSgWCSsDRhXe7IhoE564SzMlWETYjoG7SlZerMrDfLK/sS8uVMyEQXOYKV5ugr/FdPTpnstgbQXQFgH5khJqtK64Q6sr4KZHo6WfgDz2hO/jP9XWKutRPmNJoyk/e93QcijmkH7t2FxEjQUs6mv7QplDkMdpXRWQS5Bf9XIQKtVd6rpV9o2/VW0tlEJakfQ++j6Kv3r+KCH15ynicgGyvjP6lpXVt3iRoaE+PLuZTxGeKNAlYCg9FMh8+S3Vtw==
 ```
 
-GPG Fingerprint
-```
+### GPG Fingerprint
+
+```text
 6788 EA32 AA6C E2DD 3CA3  96F3 574F 2814 8305 4D44
 ```
 
-GPG Public key
+### GPG Public key
 
-```
+```text
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQINBF6p6QwBEADVKgObxrh+5ZNdB/nqNy/RemyhCVo+NQ38nbWRIhu426LEhOfc
@@ -204,20 +215,22 @@ MXdxSGZ0NEo3Qaea28NjWZv85kAvGfwd8b4Wk2cxpQlLvvWWxn2pvLr8nJcb0Gn6
 
 ## frju365
 
-SSH
-```
+### SSH key
+
+```text
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDhXPdKezUT9N94PMCqeNPb799+G2TzYEJVsx4hT8lCOQMdvapMyxN73mAEka3slRhOckXcponk/By44n1mkSXSZ+mAZNiXCoaKjOeybkKwVrOe5aG659HX/AOKOmKaIJHZyn67MPzBIKCfl4LXHhrGAiMy5hv/LZVuF9swsrQptXCwdzr07wCePmOwGGdHQ8+amSGMalao6M/34Am6SH2XUI9hNpq/9rbXO+RK2TMvWzR09hXBWtREv1n1RC/GdnXxDruJ0HSrtyiVxhbbATKDwOPrQ94yvro+6mzNE0+sd8MbIaz0jJZC8QUECNyGMBSeQhsk00S1EvaP5DN6UlR julien@julien-GAMING
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDDBOkMSSldMHTwlTCaiYsjM7JVFaLMTrytjskdZ8R8H6vKZvM5eP7CAtz8bY7J0tTFnNskr7hUX5YIhRloFH5xnHjih4dGflIqrUf5OYiM8wZcRudZ4+7yvGE7tA6T5NuElMv8jNKPDkOmdfrGQen6sI/N6xL7pQXy3fOwlrPQW9s0C6OalhfQYFLSid5b1G/HHezCvjQBFTwI5Cz0afA/yoAWjJ5UIzE7a2XUKMfgN0Cq67VlSihLA6giE0MznfBOAgW8yTQ0iQ1MNjSMnu4oVev3Qkbxt3I0OzCE+IwhXnWaR4zxFrPVUKMfLa/XiYdT42ech1JgNJolHvmfXBpV49A3rrgR8ErDVXzNsnEhAsZzeUrUgQxn0ueYrzJUAYW0o+Zv7B6oshCEfdovDGhtD7uqlrRMt90kZ1hMv1lz6UZDA0sVKLZ52iRKAqaidjKbRn4SkZwE93i8+MFQAjfxVSieAcyjXunbZyWvkd4gj45yawOpWAtMFG9/TJ9jntPwxaNCR2OIJ5Ge/o5qTfey7R364rIdZ7/3tkTW5ws7cHmLgon9wowOfG9wLqcQIYgDifpgIZFjC2ye6Qb+kNXyCN6L4oa9ykiDd+8XQVBitONoO3Y5JQ0Ub7NiUPl5Gvv8DKfTjIQ++z+c60+RVg51GTjMq8dRqshaczEMp8JVlw== abld@abld.info
 ```
 
-GPG Fingerprint
-```
+### GPG Fingerprint
+
+```text
 ACCB 5A3F F1CE 04C5 B741  9756 4277 4961 5D21 5F2B
 ```
 
-GPG Public key
+### GPG Public key
 
-```
+```text
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQINBGENcHwBEACsYHs9fPk8g+nm91K7kAlenHfYGs33rl9KFYSgOUQNftjKPKRl
@@ -250,51 +263,59 @@ t237JqA7Y18YTCk=
 ```
 
 ## JimboJoe
-SSH
-```
+
+### SSH key
+
+```text
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDxUReeafNKvISKVNQxxLujkN4RaGyKgC/C58BuKnli33T/SLagSb4UncygXg0S/bluXmSI0Qts+Hy9zi5Xnza8c5RoaGMw+S39J4xvqah6QCIP9aVtnqWSUBtDlVGUWyzZtnLVodbTRJ9BJfK9vAj+J625XwrF5XLhlJe/Xi/xw9IL/FRp7wZrRuNiFtHahDuC3GMawZxCSRdDlW0gKzldyIng7REkM1tkXWwCe5alIhx6kVGgVRjO+eqxJe3OAg4q9OMSEJMbiasa8aHv7yhrwWZInjMECPGd76qL0QhSAIv8BOdeCj7nBUgzdSED9m6u0rqG2vFQNtGt4EJMwHeX jimonin@LFR019516
 ```
 
-GPG Fingerprint
-```
+### GPG Fingerprint
+
+```text
 ```
 
-GPG Public key
-```
-```
+### GPG Public key
 
+```text
+```
 
 ## Josue-T
-SSH
-```
+
+### SSH key
+
+```text
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG9ldz5F0QrdX24sdOqTuSwS9BetmffKssUDIHXL3/Cb josue@Latitude-E6510
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICsSgNEDy3XSd5243hG0z6TFF1lCmrd0UNA6oSTPH7iR josue@Latitude-E6420
 ```
 
-GPG Fingerprint
-```
-```
+### GPG Fingerprint
 
-GPG Public key
-
-```
+```text
 ```
 
+### GPG Public key
 
+```text
+```
 
 ## Kayou
-SSH
-```
+
+### SSH key
+
+```text
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICEmMpUKk04G7300BLhaaPMf8Dfa+LA7XV0Nq+diaV5B pierre@kayou.io
 ```
 
-GPG Fingerprint
-```
+### GPG Fingerprint
+
+```text
 C090 F381 CA99 FE71 2ED6  98D8 0D31 345E D495 2B91
 ```
 
-GPG Public key
-```
+### GPG Public key
+
+```text
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQINBGEWxxUBEAC5KTd27qIlbSnkT6thiHNuopw8gOsukc4qw2pj2GtxkQhZktNL
@@ -350,19 +371,22 @@ i4k7wOqq3f/O+nzlbsTj/DFXodUepcNSuX1TxFcmJIBRsvQ=
 
 ## ljf
 
-SSH
-```
+### SSH key
+
+```text
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDGgSwBBo90Eda5lr33dYDT81DSOTkUNnLbIHqwv7Taj ljf@pirouette
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAOrQwIv/s/a3+Z42H6j8O4uunfQBQIOdUXOb9kyuYNO ljf@torche
 ```
 
-GPG Fingerprint
-```
+### GPG Fingerprint
+
+```text
 D96B 4FEA 0C22 04A2 B17C 4F18 00A3 5C27 0CC6 A81D
 ```
 
-GPG Public key
-```
+### GPG Public key
+
+```text
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mDMEXtvjwhYJKwYBBAHaRw8BAQdATbYSldUjtcuzfiCwi0jP5IWkJP0NJ3FNW2Wz
@@ -382,8 +406,9 @@ Ro3YVfbRE1uk9i3kUwD7BAOhlstNf+Dj6gwHwow5KKP0Mfi6r7yjiCpRdS2tKgA=
 
 Contact email: mathieuw[at]globenet.org
 
-SSH public key (laptop)
-```
+### SSH key public key (laptop)
+
+```text
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP6Jxt9V2rBGzfnE6jvUyCJFCwFljalrckpc49zif/7V mathieu@DellMathieu
 ```
 
@@ -391,23 +416,27 @@ ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP6Jxt9V2rBGzfnE6jvUyCJFCwFljalrckpc49zif/7V
 
 Contact email: felix[at]piedallu.me
 
-SSH public key (laptop)
-```
+### SSH key public key (laptop)
+
+```text
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKHBF0bRGNenuMU05qwrFVHy9YBVXkt22NFi+0GFT6z9 felix@framed
 ```
 
-SSH public key (NAS)
-```
+### SSH key public key (NAS)
+
+```text
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK8NriZ/QWFZ7oaAQ9MjO3ArfcQ8qqTMB6XJmMWsGOV1 salamandar@salamandar.fr
 ```
 
-GPG Fingerprint
-```
+### GPG Fingerprint
+
+```text
 4972 B73E B031 FB2F 91A9 4A92 C275 36D3 714F 339F
 ```
 
-GPG Public key
-```
+### GPG Public key
+
+```text
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 xsFNBFHdNp0BEADSGXAd4c6qoUEmDFf1qXBLFluyxrkdprEl07T6niyE4lPXhHIx
@@ -587,19 +616,21 @@ I7KlCt/EQrth3IUeae8AHON76pROqYrbX0XEXrI/
 
 Contact email: tituspijean{at}outlook.com
 
-SSH
-```
+### SSH key
+
+```text
 ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAgEAg97ZVfNvMV+qYtJSJWbVhBeXIM9OcifEuFAXicYEu4geERFghHwFAJe8dncFam2IMfiVW5rQ3vz3jOyLqEwMg8+E9RmYW+Jrs3HlLTA1QdjRZvNdIIWvmIgLjgG4ok+k8zap9XgSEBC3rHLSrQJ0/srtYfPEsldiy3Fw2FK6N/ic9nyYv/ZetuIPY7+myfppvZZe4gMO/lBYKxPe/DhDMq462yL60ugX9B7UcOAEgFJoPKkacLstV/eCUf4X6SkQQ2p7tsz8NOQ1FcGkdS5BsYYFNbOnllrFAk/A93JyjeeuINR6XXSekAK513atyxCDvKSIcW6uny0ta8NLU1lPc4QLupY5Ua+b7cmRW/hCyFlIcJb74MekmTSvxbs1TI/AewRpyzxjXr34zUnhdan4DsEwAEJ5p+kZPu0/vBjgsTkRDTte4qHMLZXEL7kXCg5m2Hi8IisIZKVWAnb888iqerJvbJQ9Din0y+QbSjk2UN3D6zd4C7swxOUNQHze+aAEUW6kiGK+P2+RmwPJ6ZBs5e+hkI4R6Imj38xdwv9YQOyXn095KMPCmWuo3MHAVpf2CRdznm0h/12pAkx/UIT9U73x5KKkWuM+8CGQMZTEn1U4+0ZwzROnWVLQ08VRqXzlskNfD2KDl/wLWuURbuDxaacx+y8t4j1gSzKB/n5gXmc= tituspijean
 ```
 
-GPG Fingerprint
-```
+### GPG Fingerprint
+
+```text
 4D96 9C81 8690 DF22 4ABE  7103 EF3B 0D7C C0A9 4720
 ```
 
-GPG Public key
+### GPG Public key
 
-```
+```text
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQINBGEhM2cBEAC0o9HR1CsOHwRXhRxkeA/X2UlZHFMJsj4nE6Z3Ccz3eV10ID3e
@@ -654,50 +685,57 @@ iQ==
 -----END PGP PUBLIC KEY BLOCK-----
 ```
 
-
 ## Yalh76
-SSH
-```
+
+### SSH key
+
+```text
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC90WdsVq7gRI/OCrowDYMKCo+u9I7E9VCSr6aXPzs2V yalh
 ```
 
-GPG Fingerprint
-```
+### GPG Fingerprint
+
+```text
 ```
 
-GPG Public key
+### GPG Public key
 
-```
+```text
 ```
 
 ## Tag
-SSH
-```
+
+### SSH key
+
+```text
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN4zQHEpRO1gZM20sEz6Z6FpX5FoHAWvtUL4Vs1tg9WE tag
 ```
 
-GPG Fingerprint
-```
+### GPG Fingerprint
+
+```text
 ```
 
-GPG Public key
+### GPG Public key
 
+```text
 ```
-```
-
 
 ## OniriCorpe
-SSH
-```
+
+### SSH key
+
+```text
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAb+PnME7+BFnFq+7Xx4Y3QA9sdoP4xBwkj33gh1Ksn+ krau
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKFOJbpru1JJZoVSHeCz7VENQxAF17icAx28S3Imhfiy apple
 ```
 
-GPG Fingerprint
-```
+### GPG Fingerprint
+
+```text
 ```
 
-GPG Public key
+### GPG Public key
 
-```
+```text
 ```

--- a/yunohost_project_organization.md
+++ b/yunohost_project_organization.md
@@ -10,7 +10,7 @@ More specifically, in line with the values of the project, it is important to:
 - limit power asymmetries
 - have a formal decision-making mechanism, e.g. to resolve a conflict, or to develop the collective or the project
 
-# Goal of the YunoHost project
+## Goal of the YunoHost project
 
 In a context where the evolution of technological tools lead to major societal challenges, YunoHost advocates an Internet that is decentralised and that allows people to remain in control of their data and their digital tools. One of the tenets of such an Internet is to drastically simplify, make accessible and to democratise server administration, when this is traditionnaly reserved to a technical elite.
 
@@ -18,33 +18,32 @@ As such, the goal of the YunoHost project is to build an operating system and al
 
 The YunoHost collective is close to other like-minded collectives, such as FFDN, Framasoft, CHATONS, or La Quadrature du Net. The collective is also sensitive to ecological issues and inclusivity.
 
-## Spirit and values of the project
+### Spirit and values of the project
 
-0. 1. **Digital commons**: all software produced by the YunoHost project is published as Free Software and will remain Free. YunoHost is developed and maintained mostly by volunteers in an open, horizontal community, that does their best with the time, means and energy they have.
+1. **Digital commons**: all software produced by the YunoHost project is published as Free Software and will remain Free. YunoHost is developed and maintained mostly by volunteers in an open, horizontal community, that does their best with the time, means and energy they have.
+2. **Accessibility**: the design of YunoHost is centered on people with little technical knowledge. Its processes, interfaces and documentation should be simple and educational.
+3. **Security**: YunoHost must provide a fairly up to date system, with reasonable security by default, and guide the users on ways to harden their system.
+4. **Hackability**: YunoHost must allow its users to take ownership of and modify their installation, to adjust it to their needs, or specific use cases, or uses that are not yet covered, or to tweak the look and feel.
 
-1. 2. **Accessibility**: the design of YunoHost is centered on people with little technical knowledge. Its processes, interfaces and documentation should be simple and educational.
+## YunoHost organization's
 
-2. 3. **Security**: YunoHost must provide a fairly up to date system, with reasonable security by default, and guide the users on ways to harden their system.
+YunoHost is developed and maintained by community of volunteers. The community has an open and horizontal structure.
 
-3. 4. **Hackability**: YunoHost must allow its users to take ownership of and modify their installation, to adjust it to their needs, or specific use cases, or uses that are not yet covered, or to tweak the look and feel.
+Members of YunoHost are part of :
 
-# Yunohost organization's
-Yunohost is developed and maintained by community of volunteers. The community has an open and horizontal structure.
-
-Members of Yunohost are part of :
 - regular users
 - occasional contributors
 - regular contributors
 
 The community organizes regulary meetings who are open to everyone. You can find the date on the forum of project. <small>(Actually these meetings are planned the 1st and 3rd tuesday every month on Mumble.)</small> The notes of these meetings are public as well.
 
-## Users
+### Users
 
 This refers to the people who use YunoHost in their daily life, who ask for help, speak about bugs and make contributions.
 
 The community is aware about the importance to listen to users and take advice about their contributions for the future of the project.
 
-## Occasional contributors
+### Occasional contributors
 
 These are the people who contribute to the project on an ad hoc basis. Any person wishing to do so is, without prior agreement, welcome and entitled to contribute to the project (provided that they do not go against the values of the project).
 
@@ -54,7 +53,7 @@ Contributions often take the form of *Pull Request* (PR) (for example, on the *c
 
 With some exceptions, occasional contributors can help with reviews, but they do not act to integrate their work into the project. They also do not have a vote in formal decision-making. They are, however, welcome to express their opinions if they wish.
 
-## Regular contributors (RC)
+### Regular contributors (RC)
 
 These are the people who regularly contribute to the project in the form of work, ensure the review and integration of the work of other contributors, as well as the short and long term maintenance of the project as a whole.
 
@@ -75,8 +74,7 @@ Regular contributors are expected to coordinate regularly with the rest of the t
 
 The loss of membership of a group takes place by voluntary departure of the person, or following a vote of radiation for inactivity, non-respect of the charters or the values of the project, or abuse of the rights of administration.
 
-
-# Validation and integration of PR
+## Validation and integration of PR
 
 Due to the nature of the project, contributions are mainly made in the form of "pull requests" (PR) or "merge requests" (MR). The realization, the review, and the collective validation of PRs are important issues, since they are precisely what makes the project alive from a purely technical point of view.
 
@@ -84,13 +82,13 @@ Behind each integration request can be hidden various human and technical issues
 
 A crucial issue in the organization of the project is therefore to find a set of rules and good practices that allow for a fluid, balanced operation, with validation as much as possible by consensus, and that distributes the responsibility to the collective rather than to individuals.
 
-## Best practices and recommendations
+### Best practices and recommendations
 
 - When a job has significant implications (or, for occasional contributors), it is strongly encouraged to discuss it in advance with the rest of the team to ensure that the imagined implementation fits with the spirit of the project and with the other work of the team.
 - Correctly describe its RP and the problem it addresses (and if applicable, the technical details needed to test)
 - Ensure the correction of problems reported by the automatic testing tools (CI)
 
-## Validation process
+### Validation process
 
 This section details the process of validating the RPs in the different repositories of the project. The objective of this process is to achieve a "soft consensus".
 
@@ -104,11 +102,11 @@ Other contributors may freely take part in the review of an RP. The author of an
 
 If a disagreement emerges during or after the validation of a PR, a cordial discussion should be held with the rest of the team in order to reach a consensus on the way forward. If no consensus is reached, a vote is held to make a decision, in which all regular contributors to the project can participate.
 
-# Collective decision making
+## Collective decision making
 
 When Regular Contributors need to make a formal decision about the project ("resolution"), or to resolve a conflict after a consensus search has failed, any Regular Contributor can initiate a formal voting process. All regular contributors can take part in this vote.
 
-# Appendix A. Group Administration Fees
+## Appendix A. Group Administration Fees
 
 This part lists the administration rights for the different groups of the YunoHost project.
 
@@ -116,24 +114,25 @@ N.B. these are not decision making rights, but access and modification rights on
 
 Members of these groups agree to abide by [the project's system administration policy](adminsyscharter.md).
 
-
 ### Core
-- GitHub: member of the [Devs team of the YunoHost organization](https://github.com/orgs/YunoHost/teams/devs) 
-    - permission to create branches, merge PRs (respecting the rules stated above)
+
+- GitHub: member of the [Devs team of the YunoHost organization](https://github.com/orgs/YunoHost/teams/devs)
+  - permission to create branches, merge PRs (respecting the rules stated above)
 - Continuous integration: access rights to Gitlab to interact with the CI core?
 - Forum: member of the [Dev group.](https://forum.yunohost.org/groups/Dev)
 -Chatrooms: admin on the Dev chatroom
 
-
 ### Apps
+
 - GitHub: (Owner) [of the YunoHost-Apps organization](https://github.com/orgs/YunoHost-Apps/people?utf8=%E2%9C%93&query=%20role%3Aowner)
-    - permission to create branches and merge PRs on all app repositories (respecting the rules stated above)
-- Github: member of the [`Apps` team of the `YunoHost` organization](https://github.com/orgs/YunoHost/teams/apps)
-    - permission to create branches and merge PR on the catalog repository (apps), exampleynh, packagelinter, packagecheck, ... (respecting the rules stated above)
+  - permission to create branches and merge PRs on all app repositories (respecting the rules stated above)
+- GitHub: member of the [`Apps` team of the `YunoHost` organization](https://github.com/orgs/YunoHost/teams/apps)
+  - permission to create branches and merge PR on the catalog repository (apps), exampleynh, packagelinter, packagecheck, ... (respecting the rules stated above)
 - Forum: Member of [`Apps` group](https://forum.yunohost.org/groups/Apps).
 - Chatrooms: admin on the Apps chatroom
 
 ### Infra
+
 - Servers: SSH access by key on some (as needed) or on all servers,
 - GitHub: member of the [`Infra` team of the `YunoHost` organization](https://github.com/orgs/YunoHost/teams/infra),
 - Forum, Weblate, XMPP, CI: administrator,
@@ -141,16 +140,16 @@ Members of these groups agree to abide by [the project's system administration p
 - Chatrooms: admin on the Dev and Infra chatroom
 
 ### Support, Doc, Communication, Translation
+
 - GitHub: member of the [`Doc` team of the `YunoHost` organization](https://github.com/orgs/YunoHost/teams/doc).
-    - permission to create branches and merge PRs on the "doc" repository (respecting the rules stated above)
+  - permission to create branches and merge PRs on the "doc" repository (respecting the rules stated above)
 - Forum: moderator status, member of the [`Support & Doc` group](https://forum.yunohost.org/groups/SupportDoc), possibility to have the group badge visible next to the avatar.
 - Diaspora*: access to the account [YunoHost](https://framasphere.org/people/01868d20330c013459cf2a0000053625),
 - Twitter: access to the [YunoHost](https://twitter.com/yunohost) account,
 - Weblate: administrator on the [translation tool](https://translate.yunohost.org/projects/yunohost/).
 - Chatrooms: admin on the Doc chatroom
 
-
-# Appendix B. Composition of the different groups 154
+## Appendix B. Composition of the different groups 154
 
 Last updated on 2022-03-15
 
@@ -159,7 +158,7 @@ Last updated on 2022-03-15
 - **Infra** : Aleks, Bram, Kayou, ljf, yalh76, tituspijean, Tagadda, OniriCorpe
 - **Support/doc/comm/trad/bureaucracy** : Aleks, Ericg, ljf, tituspijean, Tagadda, JimboJoe, wbk, OniriCorpe
 
-# Appendix C. Resolutions
+## Appendix C. Resolutions
 
 - On the fact that the commercial sale of services related to YunoHost, such as distribution, support, or outsourcing, is allowed.
 - On good app packaging practices, in particular to respect the common practice defined in exampleynh rather than factoring

--- a/yunohost_project_organization_fr.md
+++ b/yunohost_project_organization_fr.md
@@ -3,6 +3,7 @@
 Ce document a pour objectif de décrire la structure et le fonctionnement du collectif qui assure le développement et la maintenance du projet YunoHost.
 
 En particulier, en accord avec les valeurs portées par le projet, il est important de :
+
 - maintenir une transparence sur le fonctionnement du collectif et les valeurs du projet
 - d'expliciter le caractère ouvert du projet, pour que les personnes extérieures se sentent légitimes à contribuer au projet, en rejoignant ou non le collectif
 - permettre aux membres du collectif de se sentir légitimes à discuter, contribuer et acter des décisions
@@ -10,8 +11,7 @@ En particulier, en accord avec les valeurs portées par le projet, il est import
 - limiter les asymétries de pouvoir
 - avoir un mécanisme de prise de décision formel, par exemple pour résoudre un conflit, ou pour faire évoluer le collectif ou le projet.
 
-
-# Intention du projet YunoHost
+## Intention du projet YunoHost
 
 Dans un contexte où l'évolution des outils technologiques posent des enjeux sociétaux majeurs, YunoHost défend un Internet décentralisé et où les personnes restent au contrôle de leurs données et de leurs outils numériques. L'une des pierres angulaires de la construction d'un tel Internet est de drastiquement simplifier, rendre accessible et démocratiser la gestion des serveurs, là où cette pratique est traditionellement réservée à une élite technicienne.
 
@@ -19,21 +19,18 @@ Ainsi, l'objectif du projet YunoHost est de construire un système d'exploitatio
 
 Le collectif YunoHost est proche d'autres collectifs aux objectifs connexes tels que la FFDN, Framasoft, CHATONS, ou La Quadrature du Net. Le collectif est également sensible aux enjeux d'écologie et d'inclusivité.
 
-## Esprit et valeurs du projet
+### Esprit et valeurs du projet
 
-0. **Commun numérique** : Tous les éléments logiciels conçus par le projet YunoHost sont sous licence libre et le resteront. YunoHost est développé et maintenu essentiellement par le bénévolat d'une communauté ouverte, horizontale, et qui fait de son mieux en fonction du temps, des moyens et de l'énergie dont elle dispose.
+1. **Commun numérique** : Tous les éléments logiciels conçus par le projet YunoHost sont sous licence libre et le resteront. YunoHost est développé et maintenu essentiellement par le bénévolat d'une communauté ouverte, horizontale, et qui fait de son mieux en fonction du temps, des moyens et de l'énergie dont elle dispose.
+2. **Accessible** : La conception de YunoHost s'articule en priorité autour des personnes ayant peu de connaissances techniques, avec des procédures, des interfaces et des documentations simples et pédagogiques.
+3. **Sécurité** : YunoHost doit fournir un système raisonnablement maintenu à jour et raisonnablement sécurisé par défaut, et à guider les utilisateurices sur comment renforcer la sécurité de leur système.
+4. **Bidouillabilité** : YunoHost doit permettre aux utilisateurices de s'approprier et modifier leur installation pour l'adapter à des besoins ou cas d'usages spécifiques ou qui ne sont pas encore bien gérés, ou pour personnaliser l'apparence.
 
-1. **Accessible** : La conception de YunoHost s'articule en priorité autour des personnes ayant peu de connaissances techniques, avec des procédures, des interfaces et des documentations simples et pédagogiques.
-
-2. **Sécurité** : YunoHost doit fournir un système raisonnablement maintenu à jour et raisonnablement sécurisé par défaut, et à guider les utilisateurices sur comment renforcer la sécurité de leur système. 
-
-3. **Bidouillabilité** : YunoHost doit permettre aux utilisateurices de s'approprier et modifier leur installation pour l'adapter à des besoins ou cas d'usages spécifiques ou qui ne sont pas encore bien gérés, ou pour personnaliser l'apparence.
-
-# Organisation de YunoHost
+## Organisation de YunoHost
 
 YunoHost est développé et maintenu par une communauté bénévole, ouverte, horizontale.
 
-Cette communauté est composée de : 
+Cette communauté est composée de :
 
 - les utilisateurices du projet
 - les contributeurices occasionels
@@ -41,13 +38,13 @@ Cette communauté est composée de :
 
 La communauté organise à intervalle régulier des réunions de coordination en ligne, qui sont publiquement annoncées et à laquelle n'importe quelle personne peut se joindre. <small>(Plus précisément, à l'heure de l'écriture de ce document, ces réunions ont lieu les 1er et 3ème mardi de chaque mois sur Mumble, et sont annoncées sur le forum.)</small> Le compte rendu de ces réunions est également rendu public.
 
-## Les utilisateurices
+### Les utilisateurices
 
 Il s'agit des personnes qui utilisent YunoHost dans leur vie quotidienne, demandent de l'aide, rapportent des bugs et font des retours d'expérience.
 
 La communauté est consciente de l'importance de demander et de prendre en compte les retours d'expérience et les cas d'utilisation des utilisateurices dans l'évolution du projet.
 
-## Les contributeurices occasionels (OC)
+### Les contributeurices occasionels (OC)
 
 Il s'agit des personnes qui contribuent ponctuellement au projet. Toute personne le souhaitant est, sans accord prélable, bienvenue et légitime à contribuer au projet (sous couvert de ne pas aller à l'encontre des valeurs portées par le projet).
 
@@ -57,11 +54,11 @@ Les contributions se concrétisent souvent la forme de *Pull Request* (PR) (par 
 
 Sauf exception, les contributeurices occasionels peuvent aider aux revues, mais n'actent pas elleux-même l'intégration de leurs travaux dans le projet. Iels n'ont également pas non plus de droit de vote lors des prises de décisions formelles. Iels sont cependant les bienvenues pour exprimer leur avis si iels le souhaitent.
 
-## Les contributeurices réguliers (RC)
+### Les contributeurices réguliers (RC)
 
 Il s'agit des personnes qui contribuent régulièrement au projet sous la forme de travaux, assurent la revue et actent l'intégration des travaux d'autres contributeurices, ainsi que la maintenance à court et long terme du projet dans son ensemble.
 
-Les contributeurices réguliers sont organisés en groupes de travail : 
+Les contributeurices réguliers sont organisés en groupes de travail :
 
 - **Groupe Core**: travaille sur la partie "système central" du projet (principalement les dépôts YunoHost, YunoHost-Admin, Moulinette, SSOwat), ainsi que des outils de distribution (paquets .deb, images préinstallées), de développement (ynh-dev).
 - **Groupe Apps**: se concentre sur le packaging de nouvelles applications et assurent collectivement la maintenance de l'écosystème d'applications existants, ainsi que l'indexation dans le catalogue, la définition des bonnes pratiques de packaging, et des outils et métriques de contrôle qualité.
@@ -78,8 +75,7 @@ Il est attendu des contributeurices réguliers de se coordonner régulièrement 
 
 La perte de la qualité de membre d'un groupe s'opère par départ volontaire de la personne, ou suite à un vote de radiation pour inactivité, non-respect des chartes ou des valeurs du projet, ou abus des droits d'administration.
 
-
-# Validation et d'intégration des PR
+## Validation et d'intégration des PR
 
 De par la nature du projet, les contributions se concrétisent principalement sous la forme de "demandes d'intégration" (en anglais *Pull Request* (PR) ou *Merge Request* (MR)). La réalisation, la revue, et la validation collective des PR sont des enjeux importants, puisqu'ils s'agit précisément de ce qui rend le projet vivant d'un point de vue purement technique.
 
@@ -87,13 +83,13 @@ Derrière chaque demande d'intégration peut se cacher des problématiques humai
 
 Un enjeu crucial de l'organisation du projet est donc de trouver un ensemble de règles et de bonne pratiques qui permettent un fonctionnement fluide, équilibré, avec une validation autant que possible par consensus, et qui répartisse la responsabilité sur le collectif plutôt que les individus.
 
-## Bonnes pratiques et recommendations
+### Bonnes pratiques et recommendations
 
 - Lorsque un travail a des implications importantes (ou, pour les contributeurs occasionels), il est fortement encouragé de discuter en amont avec le reste de l'équipe pour s'assurer que l'implémentation imaginée convienne avec l'esprit du projet et avec les autres travaux de l'équipe.
 - Décrire correctement sa PR et le problème auquel elle répond (et le cas échéant, les détails techniques nécessaires pour tester)
 - Veiller à corriger les problèmes remontés par les outils de tests automatique (CI)
 
-## Processus de validation
+### Processus de validation
 
 Cette section détaille le processus de validation des PR dans les différents dépôts du projet. L'objectif de ce processus est d'obtenir un « consensus mou ».
 
@@ -107,11 +103,11 @@ Les autres contributeurices peuvent librement prendre part à la revue d'une PR.
 
 Si un désaccord émerge pendant ou après la validation d'une PR, une discussion cordiale doit être privilégiée avec le reste de l'équipe dans le but de dégager un consensus sur la marche à suivre. Si aucun consensus n'est trouvé, un vote est organisé pour prendre une décision, auquel peuvent prendre part toutes les contributeurices régulier du projet.
 
-# Prises de décision collective
+## Prises de décision collective
 
 Lorsque les contributeurices régulier ont besoin de prendre une décision formelle relative au projet ("résolution"), ou pour résoudre un conflit après qu'une recherche de consensus ait échoué, n'importe quel contributeurices régulier peut déclencher un processus de vote formel. Toutes les contributeurices régulier peuvent prendre part à ce vote.
 
-# Annexe A. Droits d’administration afférents aux groupes
+## Annexe A. Droits d’administration afférents aux groupes
 
 Cette partie liste les droits d’administration pour les différents groupes du projet YunoHost.
 
@@ -119,11 +115,10 @@ N.B. il ne s’agit pas des droits de prises de décisions, mais des droits d'ac
 
 Les membres de ces groupes s'engagent à respecter [la charte d'administration système du projet](adminsys_charter.md).
 
-
 ### Core
 
 - GitHub : membre de l’[équipe `Devs` de l’organisation `YunoHost`](https://github.com/orgs/YunoHost/teams/devs)
-    - permission de créer des branches, merger des PR (en respectant les règles énoncées plus haut)
+  - permission de créer des branches, merger des PR (en respectant les règles énoncées plus haut)
 - Intégration continue : droits d'accès au Gitlab pour interagir avec la CI core ?
 - Forum : membre du [groupe `Dev`](https://forum.yunohost.org/groups/Dev).
 - Chatrooms: admin sur la chatroom Dev
@@ -131,9 +126,9 @@ Les membres de ces groupes s'engagent à respecter [la charte d'administration s
 ### Apps
 
 - GitHub : propriétaire (Owner) [de l’organisation YunoHost-Apps](https://github.com/orgs/YunoHost-Apps/people?utf8=%E2%9C%93&query=%20role%3Aowner)
-    - permission de créer des branches et de merger des PR sur tous les dépôts d'app (en respectant les règles énoncées plus haut)
-- Github : membre de l’[équipe `Apps` de l’organisation `YunoHost`](https://github.com/orgs/YunoHost/teams/apps)
-    - permission de créer des branches et de merger des PR sur le dépôt du catalog (apps), example_ynh, package_linter, package_check, ... (en respectant les règles énoncées plus haut)
+  - permission de créer des branches et de merger des PR sur tous les dépôts d'app (en respectant les règles énoncées plus haut)
+- GitHub : membre de l’[équipe `Apps` de l’organisation `YunoHost`](https://github.com/orgs/YunoHost/teams/apps)
+  - permission de créer des branches et de merger des PR sur le dépôt du catalog (apps), example_ynh, package_linter, package_check, ... (en respectant les règles énoncées plus haut)
 - Forum : membre du [groupe `Apps`](https://forum.yunohost.org/groups/Apps).
 - Chatrooms: admin sur la chatroom Apps
 
@@ -148,14 +143,14 @@ Les membres de ces groupes s'engagent à respecter [la charte d'administration s
 ### Support, Doc, Communication, Traduction
 
 - GitHub : membre de l’[équipe `Doc` de l’organisation `YunoHost`](https://github.com/orgs/YunoHost/teams/doc).
-   - permission de créer des branches et de merger des PR sur le dépôt "doc" (en respectant les règles énoncées plus haut)
+  - permission de créer des branches et de merger des PR sur le dépôt "doc" (en respectant les règles énoncées plus haut)
 - Forum : statut de modérateur, membre du [groupe `Support & Doc`](https://forum.yunohost.org/groups/Support_Doc), possibilité d'avoir le badge du groupe visible à côté de l'avatar.
 - Diaspora* : accès au compte [YunoHost](https://framasphere.org/people/01868d20330c013459cf2a0000053625),
 - Twitter : accès au compte [YunoHost](https://twitter.com/yunohost),
 - Weblate : administrateur sur l’[outil de traduction](https://translate.yunohost.org/projects/yunohost/).
 - Chatrooms: admin sur la chatroom Doc
 
-# Annexe B. Composition des différents groupes
+## Annexe B. Composition des différents groupes
 
 Dernière mise à jour le 2022-03-15
 
@@ -164,7 +159,7 @@ Dernière mise à jour le 2022-03-15
 - **Infra** : Aleks, Bram, Kayou, ljf, yalh76, tituspijean, Tagadda, OniriCorpe
 - **Support/doc/comm/trad/bureaucracy** : Aleks, Ericg, ljf, tituspijean, Tagadda, JimboJoe, wbk, OniriCorpe
 
-# Annexe C. Résolutions
+## Annexe C. Résolutions
 
 - Sur le fait que la vente commerciale de services liés à YunoHost, tels que la distribution, le support, ou l'infogérance, est autorisée.
 - Sur les bonnes pratiques de packaging d'app, en particulier de respecter la pratique commune définie dans example_ynh plutôt que de factoriser

--- a/yunohost_project_tos.md
+++ b/yunohost_project_tos.md
@@ -1,17 +1,14 @@
-General and Specific Conditions of Services operated by the YunoHost project
-==============================================================================
+# General and Specific Conditions of Services operated by the YunoHost project
 
 01/02/2024
 
-Preamble
----------
+## Preamble
 
 The YunoHost project is a team of volunteers who have made common cause to create a free operating system for servers, called YunoHost. YunoHost is published [under the GNU Affero General Public License v3](https://www.gnu.org/licenses/agpl-3.0.txt). In connection with this software, the project administers and makes available several technical and community services for various purposes.
 
 By using these services, you agree to be bound by the following terms.
 
-Short version (TL;DR)
---------------
+## Short version (TL;DR)
 
 - **"This is a community project" clause**: you accept and respect the fact that the project is maintained by team of volunteers, and that volunteer time and energy are the driving force behind the project. You are welcome to contribute to the project, punctually or over time, in any way you choose (whether it's talking about it around you, giving us constructive feedback, helping others, saying hi, translating, testing, coding, donating, ...).
 - **"We do what we can" clause**: You accept that the volunteer team does the best it can, and is not subject to any obligation of means or result. The project cannot be held responsible for any consequential damage if a service ceases to operate. The team may decide to stop a service at any time.
@@ -22,8 +19,7 @@ Short version (TL;DR)
 - **"We do not want to go to jail " clause**: you must respect the law (whether it's well-made or silly).
 - **"Any abuse will be punished" clause**: technical or human abuse of the services may result in the closure of your accounts and the banning of access to some or all of the services, possibly without warning or negotiation.
 
-Distinction between YunoHost as a project, as a service, as software, and as distribution
-----------------------------------------------------------------------------------------------------------------------
+## Distinction between YunoHost as a project, as a service, as software, and as distribution
 
 This document details the TOS that apply **to the services provided by the YunoHost project**, but **not** to YunoHost as software **nor** to the applications offered in the YunoHost catalog.
 
@@ -31,17 +27,16 @@ YunoHost as software is released [under the AGPLv3 license](https://www.gnu.org/
 
 *If you use YunoHost to provide services to others, it is your responsibility to define and publish your own terms and conditions of use for your own services, and to inform yourself of any legal implications of the applications you install.*
 
-General and specific conditions of service
-------------------------------------------------------------
+## General and specific conditions of service
 
 The YunoHost project reserves the right to update and modify these conditions. In this case, the YunoHost project will inform those concerned by posting a notice on the forum or, failing that, on the site.
 
-A dated version history of these conditions can be found at https://github.com/YunoHost/project-organization/commits/master/yunohost_project_tos_fr.md
+A dated version history of these conditions can be found at <https://github.com/YunoHost/project-organization/commits/master/yunohost_project_tos_fr.md>
 
-Services overview
----------------------------
+## Services overview
 
 The services administered and maintained by the project to date are:
+
 - a public website, designed to present the project and provide documentation;
 - hosting of installation scripts, images, packages and cryptographic keys for installing and updating YunoHost;
 - a public community forum, to support each other and discuss problems or any other topic related to the project;
@@ -53,15 +48,15 @@ The services administered and maintained by the project to date are:
 - other development and maintenance services.
 
 In addition, the project depends on, uses, or encourages the use of services managed by third parties, such as:
-- software blocks and automatic installation recipes (apps) hosted by third parties such as (non-exhaustive list) github.com, npmjs.org, pypi.org, debian.org, sury.org, ...
-- several public community chat rooms using Matrix, XMPP and IRC protocols, hosted by third parties such as (non-exhaustive list) matrix.org and libera.chat;
+
+- software blocks and automatic installation recipes (apps) hosted by third parties such as (non-exhaustive list) `github.com`, `npmjs.org`, `pypi.org`, `debian.org`, `sury.org`, ...
+- several public community chat rooms using Matrix, XMPP and IRC protocols, hosted by third parties such as (non-exhaustive list) `matrix.org` and `libera.chat`;
 - the Let's Encrypt certification authority;
 - a donation interface, where payments are managed by Stripe and sent to Support Self-Hosting, the association that collects and manages donations;
 
 It is your responsibility to consult the conditions of use of these third-party services.
 
-Access to services
-------------------
+## Access to services
 
 ### Geographic scope
 
@@ -70,6 +65,7 @@ The YunoHost project services are intended for all YunoHost users and contributo
 ### Permission to use services
 
 Unless otherwise specified, use of the YunoHost project services is limited to use within the expected framework:
+
 - discovering or using the YunoHost operating system
 - contribution to the YunoHost project
 
@@ -78,14 +74,14 @@ Any other use (e.g. use in another distribution, creation of artificial intellig
 ### Account-based services and termination
 
 The following functionalities are accessible via an account:
+
 - forum posting ;
 - voting for applications in the catalog (on `apps.yunohost.org`) ;
 - reservation and management of dynamic domain names provided by the YunoHost project (`nohost.me`, `noho.st` and `ynh.fr`).
 
 The forum account and the account managing your domain name can be terminated using the associated credentials.
 
-How it works
---------------
+## How it works
 
 ### Financial conditions
 
@@ -113,8 +109,7 @@ The YunoHost project is not subject to any obligation (neither of means nor of r
 
 In particular, the YunoHost project cannot be held liable if you have made vital interests dependent on its services.
 
-Misuse of services
----------------------
+## Misuse of services
 
 **Any abuse may result in the closure of your accounts and the prohibition of access to all or part of the services**.
 
@@ -142,16 +137,15 @@ In particular, the YunoHost project will be uncompromising whenever your behavio
 
 If you abuse the service, for example by monopolizing shared machine resources, its content or access may be removed.
 
-Our commitments
----------------
+## Our commitments
 
 ### CHATONS Charter
 
 **The YunoHost project's long-term aim is to respect the charter of the Collectif des Hébergeurs, Alternatifs, Transparents, Ouverts, Neutres et Solidaires (Collective of alternative, transparent, open, neutral and supportive hosting providers) as part of its service provision activities**.
 
-Given its international scope, the YunoHost project is not currently a candidate for membership of this collective. However, members of the C.H.A.T.O.N.S collective are currently using Yunohost.
+Given its international scope, the YunoHost project is not currently a candidate for membership of this collective. However, members of the C.H.A.T.O.N.S collective are currently using YunoHost.
 
-For more information on the C.H.A.T.O.N.S. charter: https://chatons.org/charte
+For more information on the C.H.A.T.O.N.S. charter: <https://chatons.org/charte>
 
 ### Respect for your personal data and privacy
 
@@ -160,6 +154,7 @@ We try to minimize as much as possible the personal data that may transit, be st
 The YunoHost project prohibits any resale or transfer of personal data to third parties.
 
 Below are details of the personal data that may be transferred or stored on YunoHost services:
+
 - technical information (IP, User agent) used to interact with the services. This information is used to provide the service, to ensure its maintenance and security, and to create very basic aggregated statistics.
 - e-mail address and pseudonym used on the forum
 - personal information contained in messages exchanged via the forum or chat room
@@ -186,8 +181,7 @@ The YunoHost project undertakes, with respect to the services it makes available
 
 Nevertheless this does not mean in any way that *YunoHost software*, nor the applications offered for installation, would be certified with any GDPR compliance (whatever that may mean for you).
 
-Disputes and jurisdiction
---------------------------------
+## Disputes and jurisdiction
 
 The law applicable to the present contract is French law. In the event of a dispute, the parties shall seek an amicable solution. If this fails, the dispute will be settled by the Tribunal de Grande Instance de Toulouse (FRANCE).
 
@@ -195,38 +189,37 @@ The fact that the user or the YunoHost project does not take advantage at a give
 
 The nullity of one of the clauses of these conditions in application of a law, regulation or court decision does not imply the nullity of all the other clauses. Furthermore, the general spirit of the clause must be maintained in accordance with the applicable law.
 
-Specific Conditions of Services
-==================================
+---
 
-Website and documentation
--------------------------
+## Specific Conditions of Services
 
-### Service address
+### Website and documentation
+
+#### Service address
 
 `yunohost.org`
 
-### Contribution
+#### Contribution
 
-If you find an error, don't hesitate to suggest a correction, via the "Edit" button (requires a Github account) or via a message on the forum.
+If you find an error, don't hesitate to suggest a correction, via the "Edit" button (requires a GitHub account) or via a message on the forum.
 
-### Personal data
+#### Personal data
 
 To the best of our knowledge, none of the pages on this website contain trackers.
 
 As with any web service, a technical log exists recording the IP and User Agent of requests.
 
-Donations
-----
+### Donations
 
-### Service address
+#### Service address
 
 `donate.yunohost.org`
 
-### Stop recurring donation
+#### Stop recurring donation
 
 To stop your recurring donation, please send an email to `donate-5542 AT yunohost.org` and indicate the information that will identify your donation (email used, name, amount).
 
-### Personal data
+#### Personal data
 
 To provide this service, the Support Self-Hosting association uses Stripe as its payment infrastructure.
 
@@ -234,66 +227,58 @@ It is necessary to use a credit card and your identity, but these data are not s
 
 As with any web service, a technical log exists recording the IP and User Agent of requests.
 
-
-
-
-Installation media (ISO image, ARM, installation script, etc.)
----------------------------------------------------------------------
+### Installation media (ISO image, ARM, installation script, etc.)
 
 You use this service in 2 situations:
+
 - installing or restoring YunoHost
 - (rarer) to install, update or restore an app whose binary is not supplied by its publisher and whose compilation on your own machine is deemed too long or too resource-intensive.
 
-### Service address
+#### Service address
 
 `build.yunohost.org`
 
-### Personal data
+#### Personal data
 
 As with any web service, a technical log exists recording the IP and User Agent of requests.
 
-
-
-IP
-----
+### IP
 
 This service is used automatically by your YunoHost instances to determine their public IPs, enabling you to automate and diagnose certain operations.
 
-### Service addresses
+#### Service addresses
 
 `ip.yunohost.org` and `ip6.yunohost.org` addresses
 
-### Free access service
+#### Free access service
 
 Exceptionally, the public IP retrieval service can be used in other contexts, as long as the load induced is minimal relative to that of YunoHost.
 
-### Personal data
+#### Personal data
 
 As with any web service, a technical log exists recording the IP and User Agent of requests.
 
-
-Free and dynamic domain names
----------------------------------------
+### Free and dynamic domain names
 
 This is the service used if you request a domain name ending in `nohost.me`, `noho.st` or `ynh.fr` in the YunoHost interface.
 
-### Service addresses
+#### Service addresses
 
 `dyndns.yunohost.org`, `dynette.yunohost.org`, `ns0.yunohost.org`, `ns1.yunohost.org`.
 
-### Usage limits
+#### Usage limits
 
 This service is offered within the limit of one domain per YunoHost server (although it is possible to configure sub-domains of this domain). If abuse is detected (e.g. creation of too many domains from the same machine or IP, or large-scale automated creation), the project reserves the right to delete the domains concerned without warning.
 
-### Automatic deletion
+#### Automatic deletion
 
 The YunoHost project reserves the right to delete a domain if no server appears to be associated with it and the IP address has not been updated for 1 year.
 
-### Termination
+#### Termination
 
 You can delete your domain using the password you chose when you created it.
 
-### Personal data
+#### Personal data
 
 If your name contains personal data, these will inevitably end up on the servers running the service.
 
@@ -301,46 +286,43 @@ Note that, in order to function, this service necessarily stores and transmits y
 
 As with any web service, a technical log exists recording the IP and User Agent of requests.
 
-
-Diagnostics
-------------
+### Diagnostics
 
 This service automatically tests whether your services seem to be correctly exposed on the Internet, and thus independently resolves network configuration problems.
 
 This service is used automatically twice a day, as soon as you activate the diagnostics feature.
 
-### Service address
+#### Service address
 
 `diagnosis.yunohost.org`
 
-### Usage limits
+#### Usage limits
 
 Due to the resource consumption involved, the diagnosis service is limited to 60 domains to be diagnosed per request.
 
 If you exceed this limit, the project recommends that you diagnose your domains yourself.
 
-### Personal data
+#### Personal data
 
 To operate, this service transmits the domain names and ports to be diagnosed. Any personal data contained in the domain names is therefore also transferred, but not stored.
 
 As with any web service, a technical log exists recording the IP and User Agent of requests.
 
-Application catalog
-------------------------
+### Application catalog
 
 This service lets you browse (via a browser or program) the list of applications available for installation in YunoHost. It also allows you to vote for apps to direct contribution efforts.
 
 In addition, servers running YunoHost automatically retrieve the application catalog once a day.
 
-### Service addresses
+#### Service addresses
 
 `apps.yunohost.org` and `app.yunohost.org`.
 
-### Service misuse
+#### Service misuse
 
 Any attempt to falsify votes on catalog or wishlist apps will be considered abuse and may be subject to cancellation, banning and account deletion.
 
-### Personal data
+#### Personal data
 
 To participate in the popularity of apps, you need to use your forum account. See Forum service.
 
@@ -348,89 +330,82 @@ The storage of your votes is linked to your forum identity.
 
 As with any web service, a technical log exists recording the IP and User Agent of requests.
 
-### Statistics
+#### Statistics
 
 In order to size our services and plan new releases, we use the technical download logs from the list of apps to estimate the number of YunoHost instances running in the wild, and the ratio of major releases.
 
-debian package repository
-----------------------
+### Debian package repository
 
 This is the channel through which updates to YunoHost as software are made available. The YunoHost project also maintains builds of some software components on which YunoHost depends or on the periphery of the project.
 
-### Service address
+#### Service address
 
 `forge.yunohost.org`
 
-### Permission to create mirror repositories
+#### Permission to create mirror repositories
 
 It is allowed (and even encouraged) to create mirror repositories of YunoHost's Debian package repository.
 
-### Personal data
+#### Personal data
 
 As with any web service, a technical log exists recording the IP and User Agent of requests.
 
-Tickets and contributions to the code
---------------------------------
+### Tickets and contributions to the code
 
 As it stands, development, bug reports and feature requests take place on the repositories of the "YunoHost" and "YunoHost-Apps" organizations on the GitHub platform.
 
-### Respect for volunteers
+#### Respect for volunteers
 
 We can only re-emphasize what has already been mentioned in the 'Respect for the community and volunteers' section above: the project is maintained by a volunteer team, volunteer time and energy is the driving force behind the project, and volunteers do their best. You're welcome to contribute to the project (and if necessary to ask questions about how to contribute) to the team.
 
 On the other hand, abusing their time or energy is tantamount to sabotaging the project. In particular, YunoHost is *not* a community of volunteers at your command regarding priorities for patches, features or updates, either for YunoHost as software, or for the catalog of applications maintained by the project. Volunteers do not promise support, fixes, features or updates, nor do they provide estimates of "when" a feature, fix or update will be available. Messages that simply ask when a feature, fix or update will be available, without any form of politeness, benevolence or intention to contribute, are not welcome and undermine volunteer morale. Any abuse may be punished by a ban from the project's GitHub organizations, or even from all project services.
 
-Paste
------
+### Paste
 
 This service is used to share logs of operations carried out with YunoHost to enable the study and resolution of problems.
 
-### Service address
+#### Service address
 
 `paste.yunohost.org`
 
-### Personal data
+#### Personal data
 
 The logs you share may contain personal information or, in the worst case, secrets that could compromise the security of part or all of your server. Upon publication, YunoHost software automatically tries to remove this information as best it can. Nevertheless, the system is far from being perfect, and it is your responsibility to re-read the information before sharing the generated link with others.
 
 As with any web service, a technical log exists recording the IP and User Agent of requests.
 
-Self-help forum (and chat)
---------
+### Self-help forum (and chat)
 
-### Service address
+#### Service address
 
-`forum.yunohost.org` and chats listed on https://yunohost.org/chat_rooms
+`forum.yunohost.org` and chats listed on <https://yunohost.org/chat_rooms>
 
-### Asking for help
+#### Asking for help
 
 The self-help forum and chat clearly state (e.g. [here](https://yunohost.org/en/help-me), [here](https://forum.yunohost.org/t/asking-for-support-demander-de-laide/7795) and [here](https://forum.yunohost.org/t/how-to-get-help-efficiently-comment-obtenir-de-laide-efficacement/27)) that in order to get help, it is **necessary** to provide basic information (hardware type, YunoHost version), background information and full logs. Not doing so is extremely annoying for the people trying to help you, especially as we strive to make sharing this information as simple as possible. In addition, it is counter-productive because it wastes everyone's time: nobody can solve a problem that is not diagnosable.
 
 If these rules are not respected, the team reserves the right to close your topic without notice.
 
-### Personal data
+#### Personal data
 
 The forum allows you to enter personal information (email, GitHub account, nickname). From the forum interface, you can modify or delete this information.
 
 As with any web service, a technical log records the IP and User Agent of requests. In addition, the forum may send or receive e-mails, which are also logged.
 
-### Location
+#### Location
 
 Paris
 
-Demo service
-----
+### Demo service
 
-### Service address
+#### Service address
 
 `demo.yunohost.org`
 
-### Purpose and operation
+#### Purpose and operation
 
 This service allows you to test YunoHost's interfaces (webadmin and user portal) to get a feel for YunoHost without installing it. The data on this server is destroyed and reset approximately every 30 minutes.
 
-### Personal data
+#### Personal data
 
 As with any web service, a technical log exists recording the IP and User Agent of requests.
-
-

--- a/yunohost_project_tos_fr.md
+++ b/yunohost_project_tos_fr.md
@@ -1,17 +1,14 @@
-Conditions Générales et spécifiques des Services opérés par le projet YunoHost
-==============================================================================
+# Conditions Générales et spécifiques des Services opérés par le projet YunoHost
 
 01/02/2024
 
-Préambule
----------
+## Préambule
 
 Le projet YunoHost est animé par une équipe de personnes bénévoles qui ont fait cause commune pour créer un système d'exploitation libre pour les serveurs, appelé YunoHost. YunoHost est publié [sous licence GNU Affero General Public License v3](https://www.gnu.org/licenses/agpl-3.0.txt). En lien avec ce logiciel, le projet administre et met à disposition plusieurs services techniques et communautaires à des fins diverses.
 
 En utilisant ces services, vous acceptez d’être lié·e par les conditions suivantes.
 
-Version courte (TL;DR)
---------------
+## Version courte (TL;DR)
 
 - **Clause « Ceci est un projet communautaire »** : vous acceptez et respectez le fait que le projet est maintenu par une équipe bénévole, et que le temps et l'énergie bénévole sont la force motrice du projet. Les contributions au projet sont les bienvenues, ponctuelles ou dans la durée, par le moyen de votre choix (que ce soit en parler autour de vous, nous faire des retours constructifs, aider les autres, faire coucou, traduire, tester, coder, donner, ...).
 - **Clause « On fait ce qu'on peut »** : vous acceptez que l'équipe bénévole fait du mieux qu'elle peut et n'est assujettie à aucune obligation, ni de moyen, ni de résultat. Le projet ne peut être tenu pour responsable des dommages ou préjudices indirects si un service cesse de fonctionner. L'équipe peut décider d'arrêter un service à tout moment.
@@ -22,8 +19,7 @@ Version courte (TL;DR)
 - **Clause « On ne veut pas finir en taule »** : vous devez respecter la loi (que celle-ci soit bien faite ou idiote).
 - **Clause « Tout abus sera puni »** : abuser techniquement ou humainement des services peut entraîner la fermeture de vos comptes et l'interdiction de l'accès à une partie ou à l'ensemble des services, possiblement sans avertissement ni négociation.
 
-Distinction entre YunoHost en tant que projet, en tant que services, en tant que logiciel, et en tant que distribution
-----------------------------------------------------------------------------------------------------------------------
+## Distinction entre YunoHost en tant que projet, en tant que services, en tant que logiciel, et en tant que distribution
 
 Ce document détaille les CGS qui s'appliquent **aux services fournis par le projet YunoHost**, mais **pas** à YunoHost en tant que logiciel **ni** aux applications proposées dans le catalogue de YunoHost.
 
@@ -31,17 +27,16 @@ YunoHost en tant que logiciel est publié [sous licence AGPLv3](https://www.gnu.
 
 *Si vous utilisez YunoHost pour fournir des services à d'autres personnes, il est de votre responsabilité de définir et publier les conditions générales d'utilisation de votre souhait pour vos propres services à l'attention de ces personnes, et de vous renseigner sur toutes les implications légales des applications que vous installez.*
 
-Évolution des conditions générales et spécifiques de service
-------------------------------------------------------------
+## Évolution des conditions générales et spécifiques de service
 
 Le projet YunoHost se réserve le droit de mettre à jour et modifier ces conditions. Dans ce cas, le projet YunoHost informe les personnes concernées par un affichage sur le forum ou à défaut sur le site.
 
-Un historique daté des versions de ces conditions peut être récupéré sur https://github.com/YunoHost/project-organization/commits/master/yunohost_project_tos_fr.md
+Un historique daté des versions de ces conditions peut être récupéré sur <https://github.com/YunoHost/project-organization/commits/master/yunohost_project_tos_fr.md>
 
-Vue d'ensemble des services
----------------------------
+## Vue d'ensemble des services
 
 Les services administrés et maintenus par le projet sont, à ce jour :
+
 - un site web public, destiné à présenter le projet et à fournir de la documentation ;
 - l'hébergement de scripts d'installation, d'images, de paquets et de clés cryptographiques liés à l'installation et à la mise à jour de YunoHost ;
 - un forum communautaire public, destiné à s'entraider et discuter des problèmes ou de tout autre sujet lié au projet ;
@@ -53,14 +48,14 @@ Les services administrés et maintenus par le projet sont, à ce jour :
 - d'autres services liés au développement et à la maintenance.
 
 En outre, le projet dépend, utilise, ou encourage l'utilisation de services gérés par des tiers, tels que :
-- des briques logicielles et recettes d'installations automatiques (apps) hébergées chez des tiers tels que (liste non-exhaustive) github.com, npmjs.org, pypi.org, debian.org, sury.org, …
-- plusieurs salons de discussion communautaires publics utilisant les protocoles Matrix, XMPP et IRC, hébergés par des tiers tels que (liste non-exhaustive) matrix.org et libera.chat ;
+
+- des briques logicielles et recettes d'installations automatiques (apps) hébergées chez des tiers tels que (liste non-exhaustive) `github.com`, `npmjs.org`, `pypi.org`, `debian.org`, `sury.org`, …
+- plusieurs salons de discussion communautaires publics utilisant les protocoles Matrix, XMPP et IRC, hébergés par des tiers tels que (liste non-exhaustive) `matrix.org` et `libera.chat` ;
 - l'autorité de certification Let's Encrypt ;
 - une interface de dons, dont les paiements sont gérés par Stripe et à destination de Support Self-Hosting, l'association qui récolte et gère les dons.
 Le cas échéant, il est de votre responsabilité de consulter les conditions d'utilisations de ces services gérés par des tiers.
 
-Accès aux services
-------------------
+## Accès aux services
 
 ### Périmètre géographique
 
@@ -69,6 +64,7 @@ Les services du projet YunoHost s’adressent à l'ensemble des utilisateurices 
 ### Permission d'utilisation des services
 
 Sauf mentions contraires, l'usage des services du projet YunoHost est limité à une utilisation dans le cadre attendu :
+
 - découverte ou utilisation du système d'exploitation YunoHost
 - contribution au projet YunoHost
 
@@ -77,14 +73,14 @@ Tout autre usage (par exemple: utilisation dans une autre distribution, créatio
 ### Services accessibles via un compte et résiliation
 
 Les fonctionnalités suivantes sont accessibles via un compte :
+
 - l'écriture sur le forum ;
 - le vote pour les applications du catalogue (sur `apps.yunohost.org`) ;
 - la réservation et la gestion de noms de domaines dynamiques fournit par le projet YunoHost (`nohost.me`, `noho.st` et `ynh.fr`).
 
 Le compte sur le forum et le compte gérant votre nom de domaine peuvent être résiliés grâce aux identifiants associés.
 
-Fonctionnement
---------------
+## Fonctionnement
 
 ### Conditions financières
 
@@ -112,8 +108,7 @@ Le projet YunoHost n'est assujetti à aucune obligation (ni de moyen, ni de rés
 
 En particulier, le projet YunoHost ne pourra être tenu responsable si vous avez fait dépendre de ses services des intérêts vitaux.
 
-Mésusage des services
----------------------
+## Mésusage des services
 
 **Tout abus peut entraîner la fermeture de vos comptes et l'interdiction de l'accès à une partie ou à l'ensemble des services.**
 
@@ -141,17 +136,15 @@ En particulier, le projet YunoHost sera intransigeant dès lors que votre compor
 
 Si vous abusez du service, par exemple en monopolisant des ressources machines partagées, son contenu ou son accès pourra être supprimé.
 
-
-Nos engagements
----------------
+## Nos engagements
 
 ### Charte CHATONS
 
-**Le projet YunoHost vise à long-terme à respecter la charte du Collectif des Hébergeurs, Alternatifs, Transparents, Ouverts, Neutres et Solidaires dans le cadre de son activité de fourniture de services**
+**Le projet YunoHost vise à long-terme à respecter la charte du Collectif des Hébergeurs, Alternatifs, Transparents, Ouverts, Neutres et Solidaires dans le cadre de son activité de fourniture de services.**
 
-Compte tenu de sa portée internationale, le projet YunoHost n'est pas, à ce jour, candidat à l’intégration au sein de ce collectif. Toutefois à ce jour des membres du collectif C.H.A.T.O.N.S utilisent Yunohost.
+Compte tenu de sa portée internationale, le projet YunoHost n'est pas, à ce jour, candidat à l’intégration au sein de ce collectif. Toutefois à ce jour des membres du collectif C.H.A.T.O.N.S utilisent YunoHost.
 
-Plus d’information sur la charte C.H.A.T.O.N.S. : https://chatons.org/charte
+Plus d’information sur la charte C.H.A.T.O.N.S. : <https://chatons.org/charte>
 
 ### Respect de vos données personnelles et de votre vie privée
 
@@ -160,6 +153,7 @@ Nous essayons de minimiser le plus possible les données personnelles qui peuven
 Le projet YunoHost s'interdit toute revente ou transfert de données personnelles à des tiers.
 
 Ci-dessous, le détail des informations personnelles susceptibles de transiter ou d'être stockées sur les services du projet YunoHost:
+
 - informations techniques (IP, User agent) utilisées pour interagir avec les services. Elles sont utilisées dans le but de fournir le service, d'en assurer la maintenance et la sécurité et de créer des statistiques agrégées très basiques ;
 - email et pseudonyme utilisés sur le forum ;
 - informations personnelles figurant dans les messages échangées via le forum ou le chat ;
@@ -186,8 +180,7 @@ Le projet YunoHost s’engage, vis à vis des services qu'il met à disposition,
 
 Néanmoins ceci ne signifie en aucun cas que *le logiciel YunoHost*, ni les applications proposées à l'installation, seraient certifiés avec une quelconque conformité au RGPD (quoi que cela puisse signifier pour vous).
 
-Litige et juridiction compétente
---------------------------------
+## Litige et juridiction compétente
 
 Le droit applicable aux présentes est le droit français. En cas de différend, les parties recherchent une solution amiable. Si la démarche échoue, le litige sera tranché par le Tribunal de Grande Instance de Toulouse (FRANCE).
 
@@ -195,38 +188,37 @@ Le fait que l’usager ou le projet YunoHost ne se prévale pas à un moment don
 
 La nullité d’une des clauses de ces conditions en application d’une loi, d’une réglementation ou d’une décision de justice n’implique pas la nullité de l’ensemble des autres clauses. Par ailleurs l’esprit général de la clause sera à conserver en accord avec le droit applicable.
 
-Conditions Spécifiques de Services
-==================================
+---
 
-Site web et documentation
--------------------------
+## Conditions Spécifiques de Services
 
-### Adresse du service
+### Site web et documentation
+
+#### Adresse du service
 
 `yunohost.org`
 
-### Contribution
+#### Contribution
 
-Si vous repérez une erreur, n'hésitez pas à proposer une correction, via le bouton "Éditer" (nécessite un compte Github) ou via un message sur le forum.
+Si vous repérez une erreur, n'hésitez pas à proposer une correction, via le bouton "Éditer" (nécessite un compte GitHub) ou via un message sur le forum.
 
-### Données personnelles
+#### Données personnelles
 
 A notre connaissance, aucune page de ce site web ne comporte de traqueurs.
 
 Comme n'importe quel service web, un journal technique existe enregistrant l'IP et le User Agent des requêtes.
 
-Dons
-----
+### Dons
 
-### Adresse du service
+#### Adresse du service
 
 `donate.yunohost.org`
 
-### Arrêt d'un don récurent
+#### Arrêt d'un don récurent
 
 Pour demander l'arrêt de votre don récurrent, merci d'envoyer un mail à `donate-5542 CHEZ yunohost.org` et d'indiquer les informations qui permettront d'identifier votre don (email utilisé, nom, montant).
 
-### Données personnelles
+#### Données personnelles
 
 Pour fournir ce service, l'association Support Self-Hosting utilise Stripe comme infrastructure de paiement.
 
@@ -234,52 +226,46 @@ Il est nécessaire d'utiliser une carte bancaire ainsi que de son identité, mai
 
 Comme n'importe quel service web, un journal technique existe enregistrant l'IP et le User Agent des requêtes.
 
-
-
-
-Supports d'installations (image ISO, ARM, script d'installation, ...)
----------------------------------------------------------------------
+### Supports d'installations (image ISO, ARM, script d'installation, ...)
 
 Vous utilisez ce service dans 2 situations:
+
 - installation ou restauration de YunoHost ;
 - (plus rare) installation, mise à jour, ou restauration d'une app dont le binaire n'est pas fournis par son éditeur et dont sa compilation sur votre propre machine est jugée trop longue ou trop coûteuse en ressources.
 
-### Adresse du service
+#### Adresse du service
 
 `build.yunohost.org`
 
-### Données personnelles
+#### Données personnelles
 
 Comme n'importe quel service web, un journal technique existe enregistrant l'IP et le User Agent des requêtes.
 
-IP
-----
+### IP
 
 Ce service est utilisé automatiquement par vos instances YunoHost pour déterminer leurs IP publiques et permettre ainsi l'automatisation et le diagnostique de certaines opérations.
 
-### Adresses des services
+#### Adresses des services
 
 `ip.yunohost.org` et `ip6.yunohost.org`
 
-### Service en libre accès
+#### Service en libre accès
 
 Exceptionnellement, le service de récupération d'IP publiques peut être utilisé dans d'autres cadres tant que la charge induite est minime relativement à celle de YunoHost.
 
-### Données personnelles
+#### Données personnelles
 
 Comme n'importe quel service web, un journal technique existe enregistrant l'IP et le User Agent des requêtes.
 
-
-Noms de domaines gratuits et dynamiques
----------------------------------------
+### Noms de domaines gratuits et dynamiques
 
 Il s'agit du service utilisé si vous demandez un nom de domaine terminant par `nohost.me`, `noho.st` ou `ynh.fr` dans l'interface de YunoHost.
 
-### Adresses des services
+#### Adresses des services
 
 `dyndns.yunohost.org`, `dynette.yunohost.org`, `ns0.yunohost.org`, `ns1.yunohost.org`
 
-### Limite d'usage
+#### Limite d'usage
 
 Ce service est proposé dans la limite d'un seul domaine par serveur YunoHost (bien qu'il soit possible de configurer des sous-domaine de ce domaine). Si des abus sont constatés (par exemple création de trop nombreux domaines depuis la même machine ou IP, ou création automatisée à large échelle), le projet se réserve le droit de supprimer les domaines concernés sans prévenir.
 
@@ -291,7 +277,7 @@ Le projet YunoHost se réserve le droit de supprimer le domaine si aucun serveur
 
 Vous pouvez supprimer votre domaine à l'aide du mot de passe choisi lors de sa création.
 
-### Données personnelles
+#### Données personnelles
 
 Si votre nom contient des données personnelles, celles-ci se retrouveront forcément sur les serveurs faisant fonctionner le service.
 
@@ -299,46 +285,43 @@ Notez que, pour fonctionner, ce service stocke et transmet nécessairement les a
 
 Comme n'importe quel service web, un journal technique existe enregistrant l'IP et le User Agent des requêtes.
 
-
-Diagnostique
-------------
+### Diagnostique
 
 Il s'agit d'un service permettant de tester automatiquement si vos services semblent correctement exposés sur internet et ainsi résoudre en autonomie les problèmes liés à la configuration réseau.
 
 Ce service est utilisé automatiquement deux fois par jour, dès lors que vous activez la fonctionnalité de diagnostique.
 
-### Adresse du service
+#### Adresse du service
 
 `diagnosis.yunohost.org`
 
-### Limite d'usage
+#### Limite d'usage
 
 En raison de la consommation de ressources induites, le service de diagnostique est limités à 60 domaines à diagnostiquer par requêtes.
 
 Si vous dépassez cette limite, le projet recommande de diagnostiquer le bon fonctionnement de vos domaines par vos propres moyens.
 
-### Données personnelles
+#### Données personnelles
 
 Pour fonctionner ce service transmet les noms de domaines et les ports à diagnostiquer. Toute donnée personnelle figurant dans les noms de domaines est donc transférée également, mais n'est pas conservée.
 
 Comme n'importe quel service web, un journal technique existe enregistrant l'IP et le User Agent des requêtes.
 
-Catalogue d'applications
-------------------------
+### Catalogue d'applications
 
 Ce service permet de consulter (via un navigateur ou un programme) la liste des applications disponibles à l'installation dans YunoHost. Il permet également de voter pour les apps afin d'orienter les efforts de contribution.
 
 De plus, les serveurs fonctionnant sous YunoHost récupèrent automatiquement le catalogue d'application une fois par jour.
 
-### Adresses du service
+#### Adresses du service
 
 `apps.yunohost.org` et `app.yunohost.org`
 
-### Mésusage des services
+#### Mésusage des services
 
 Toute tentative de falsifier les votes sur les apps du catalogue ou de la liste de souhaits sera considéré comme un abus et peut faire l'objet d'annulation, de bannissement et de suppression de compte.
 
-### Données personnelles
+#### Données personnelles
 
 Pour participer à la popularité des apps, il est nécessaire d'utiliser son compte sur le forum. Voir le service Forum.
 
@@ -346,87 +329,82 @@ Le stockage de vos votes est lié à votre identité sur le forum.
 
 Comme n'importe quel service web, un journal technique existe enregistrant l'IP et le User Agent des requêtes.
 
-### Statistiques
+#### Statistiques
 
 Afin de dimensionner nos services et planifier les nouvelles versions, nous utilisons le logs techniques de téléchargement de la liste des apps pour estimer le nombre d'instances YunoHost en fonctionnement dans la nature, et le ratio des versions majeures.
 
-Dépôt de paquet debian
-----------------------
+### Dépôt de paquet Debian
 
 Il s'agit du canal par lequel les mises à jour de YunoHost en tant que logiciel sont mises à disposition. Le projet YunoHost maintient également des "builds" de certaines briques logicielles dont YunoHost dépends ou à la périphérie du projet.
 
-### Adresse du service
+#### Adresse du service
 
 `forge.yunohost.org`
 
-### Autorisation de créer des dépôts miroirs
+#### Autorisation de créer des dépôts miroirs
 
 Il est autorisé (et même encouragé) de créer des dépôts miroirs du dépôt de paquet Debian de YunoHost.
 
-### Données personnelles
+#### Données personnelles
 
 Comme n'importe quel service web, un journal technique existe enregistrant l'IP et le User Agent des requêtes.
 
-Tickets et contributions au code
---------------------------------
+### Tickets et contributions au code
 
 En l'état, le développement, les rapports de bug et les demandes de fonctionnalités s'effectuent sur les dépôts des organisations "YunoHost" et "YunoHost-Apps" sur la plateforme GitHub.
 
-### Respect des bénévoles
+#### Respect des bénévoles
 
 Nous ne pouvons que ré-insister sur ce qui est déjà mentionné dans la section 'Respect de la communauté et des bénévoles' plus haut : le projet est maintenu par une équipe bénévole, le temps et l'énergie bénévole est la force motrice du projet, et les bénévoles font de leur mieux. Vous êtes les bienvenues pour contribuer au projet (et le cas échéant à poser des questions sur comment contribuer) à l'équipe.
 
 En revanche, abuser de leur temps ou de leur énergie équivaut à saboter le projet. En particulier, YunoHost n'est *pas* une communauté de bénévoles à vos ordres sur les priorités de correctifs, fonctionnalités ou mises à jour, ni pour YunoHost en tant que logiciel, ni pour le catalogue d'applications maintenues par le projet. Les bénévoles ne promettent ni support, ni correctifs, ni fonctionnalités, ni mise à jour, et ne fournissent pas non plus d'estimation sur "quand" une fonctionnalité, correctif ou mise à jour sera disponible. Les messages se contentant de demander quand une fonctionnalité, correctif ou mise à jour sera disponible, sans aucune forme de politesse, de bienveillance ou d'intention de contribution, ne sont pas les bienvenus et sapent le moral des bénévoles. Tout abus pourra être sanctionné par un bannissement des organisations GitHub du projet, voir de l'entièreté des services du projet.
 
-Paste
------
+### Paste
 
 Ce service sert à partager les journaux des opérations réalisées avec YunoHost pour permettre l'étude et la résolution des problèmes.
 
-### Adresse du service
+#### Adresse du service
 
 `paste.yunohost.org`
 
-### Données personnelles
+#### Données personnelles
+
 Les logs que vous partagez sont susceptible de contenir des informations personnelles ou, dans le pire des cas, des secrets qui peuvent compromettre la sécurité d'une partie ou de l'entièreté de votre serveur. Lors de la publication, le logiciel YunoHost essaie de retirer automatiquement et du mieux qu'il peut ces informations. Néanmoins, le système est loin d'être parfait, et il est de votre responsabilité de relire les informations avant de partager le lien généré avec d'autres personnes.
 
 Comme n'importe quel service web, un journal technique existe enregistrant l'IP et le User Agent des requêtes.
 
+### Forum (et chat) d'entraide
 
-Forum (et chat) d'entraide
---------
+#### Adresse du service
 
-### Adresse du service
+`forum.yunohost.org` et chats listés sur <https://yunohost.org/chat_rooms>
 
-`forum.yunohost.org` et chats listés sur https://yunohost.org/chat_rooms
-
-### Demander de l'aide
+#### Demander de l'aide
 
 Le forum et chat d'entraide stipulent clairement (par exemple [ici](https://yunohost.org/fr/help-me), [ici](https://forum.yunohost.org/t/asking-for-support-demander-de-laide/7795) et [ici](https://forum.yunohost.org/t/how-to-get-help-efficiently-comment-obtenir-de-laide-efficacement/27)) que pour espérer obtenir de l'aide, il est **nécessaire** de fournir les informations de base (type de matériel, version de YunoHost), des éléments de contexte et les journaux complets. Ne pas le faire est extrêmement agaçant pour les personnes qui tentent de vous aider, d'autant plus que nous nous efforçons de simplifier au maximum le partage de ces informations. De plus c'est contre-productif car cela fait perdre du temps à tout le monde : on ne peux pas résoudre un problème qu'on ne peut diagnostiquer.
 
 Si ces règles ne sont pas respectées, l'équipe se réserve le droit de fermer votre sujet sans préavis.
 
-### Données personnelles
+#### Données personnelles
 
 Le forum permet d'indiquer des informations personnelles (email, compte GitHub, pseudo). À partir de l'interface du forum, vous avez la main pour modifier et supprimer ces données.
 
 Comme n'importe quel service web, un journal technique existe enregistrant l'IP et le User Agent des requêtes. De plus, le forum est susceptible d'envoyer ou recevoir des emails, qui sont également journalisés.
 
-### Localisation des données
+#### Localisation des données
 
 Paris
 
-Service de démonstration
-----
+### Service de démonstration
 
-### Adresse du service
+#### Adresse du service
 
 `demo.yunohost.org`
 
-### Objectif et fonctionnement
+#### Objectif et fonctionnement
 
 Ce service permet de tester les interfaces de YunoHost (webadmin et portail utilisateur) pour découvrir et se faire une idée de YunoHost sans l'installer. Les données de ce serveur sont détruites et réinitialisées toutes les 30 minutes environ.
 
-### Données personnelles
+#### Données personnelles
 
 Comme n'importe quel service web, un journal technique existe enregistrant l'IP et le User Agent des requêtes.


### PR DESCRIPTION
sorry for this giant PR 🙃

- added `.markdownlint.json` to configure the linter (it's the same config as on [ynh/doc](https://github.com/YunoHost/doc))
- automatic linting according to the config
- manual corrections for titles for **TOS**:
  - typically to correct the mix of different types of titles, which is really weird to read as bare markdown
  - fix "mutiple first level titles" errors (added `---` to visually separate the document before `Specific Conditions of Services`)
  - fix many wrongly leveled titles
- add third level title for keys in the `ynh-keys.md` file, to generate a table of contents like this:
![ascreenshot showing the table of content for the OniriCorpe user, with SSH key, GPG Fingerprint and GPG Public key as links](https://github.com/YunoHost/project-organization/assets/6963387/d5010532-9b06-4dcb-b961-9ce474cf8fd3)
